### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main]


### PR DESCRIPTION
Potential fix for [https://github.com/qdrant/qcloud-cli/security/code-scanning/3](https://github.com/qdrant/qcloud-cli/security/code-scanning/3)

In general, this issue is fixed by adding an explicit `permissions:` block to the workflow (at the top level, applying to all jobs) or to each job individually, granting only the minimum scopes required. For typical CI jobs that just check out code and run tests or linters, `contents: read` is sufficient.

For this specific workflow, none of the jobs pushes commits, creates releases, or modifies issues/PRs. They run linters, tests, `go mod tidy`, and check for uncommitted changes locally. Therefore the single best fix is to add a workflow-level `permissions:` block setting `contents: read`. This will apply to all three jobs (`lint`, `test`, `go-mod-tidy`) without changing their functionality.

Concretely, in `.github/workflows/ci.yml`, add:

```yaml
permissions:
  contents: read
```

near the top of the file, right after the `name: CI` line and before the `on:` block. No imports or extra methods are needed because this is a YAML configuration change only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
