### PR TITLE
fix: package matching now uses cpu and ram

### DIFF
--- a/internal/cmd/cluster/completion.go
+++ b/internal/cmd/cluster/completion.go
@@ -128,9 +128,9 @@ func versionCompletion(s *state.State) func(*cobra.Command, []string, string) ([
 	}
 }
 
-// filteredPackages fetches active packages filtered by non-empty cpu/ram/disk/gpu values and the multiAz flag.
+// filteredPackages fetches active packages filtered by non-empty cpu/ram values and the multiAz flag.
 // Returns nil (no completions) if --cloud-provider is not set.
-func filteredPackages(cmd *cobra.Command, s *state.State, cpu, ram, disk, gpu string, multiAz bool) ([]*bookingv1.Package, error) {
+func filteredPackages(cmd *cobra.Command, s *state.State, cpu, ram string, multiAz bool) ([]*bookingv1.Package, error) {
 	provider, _ := cmd.Flags().GetString("cloud-provider")
 	if provider == "" {
 		return nil, nil
@@ -174,12 +174,6 @@ func filteredPackages(cmd *cobra.Command, s *state.State, cpu, ram, disk, gpu st
 		if ram != "" && rc.GetRam() != ram {
 			continue
 		}
-		if disk != "" && rc.GetDisk() != disk {
-			continue
-		}
-		if gpu != "" && rc.GetGpu() != gpu {
-			continue
-		}
 		result = append(result, p)
 	}
 	return result, nil
@@ -193,10 +187,8 @@ func cpuCompletion(s *state.State) func(*cobra.Command, []string, string) ([]str
 			return nil, cobra.ShellCompDirectiveNoFileComp
 		}
 		ram, _ := cmd.Flags().GetString("ram")
-		disk, _ := cmd.Flags().GetString("disk")
-		gpu, _ := cmd.Flags().GetString("gpu")
 		multiAz, _ := cmd.Flags().GetBool("multi-az")
-		pkgs, err := filteredPackages(cmd, s, "", ram, disk, gpu, multiAz)
+		pkgs, err := filteredPackages(cmd, s, "", ram, multiAz)
 		if err != nil {
 			return nil, cobra.ShellCompDirectiveError
 		}
@@ -222,10 +214,8 @@ func ramCompletion(s *state.State) func(*cobra.Command, []string, string) ([]str
 			return nil, cobra.ShellCompDirectiveNoFileComp
 		}
 		cpu, _ := cmd.Flags().GetString("cpu")
-		disk, _ := cmd.Flags().GetString("disk")
-		gpu, _ := cmd.Flags().GetString("gpu")
 		multiAz, _ := cmd.Flags().GetBool("multi-az")
-		pkgs, err := filteredPackages(cmd, s, cpu, "", disk, gpu, multiAz)
+		pkgs, err := filteredPackages(cmd, s, cpu, "", multiAz)
 		if err != nil {
 			return nil, cobra.ShellCompDirectiveError
 		}
@@ -252,9 +242,8 @@ func diskCompletion(s *state.State) func(*cobra.Command, []string, string) ([]st
 		}
 		cpu, _ := cmd.Flags().GetString("cpu")
 		ram, _ := cmd.Flags().GetString("ram")
-		gpu, _ := cmd.Flags().GetString("gpu")
 		multiAz, _ := cmd.Flags().GetBool("multi-az")
-		pkgs, err := filteredPackages(cmd, s, cpu, ram, "", gpu, multiAz)
+		pkgs, err := filteredPackages(cmd, s, cpu, ram, multiAz)
 		if err != nil {
 			return nil, cobra.ShellCompDirectiveError
 		}
@@ -263,38 +252,6 @@ func diskCompletion(s *state.State) func(*cobra.Command, []string, string) ([]st
 		var completions []string
 		for _, p := range pkgs {
 			v := p.GetResourceConfiguration().GetDisk()
-			if _, ok := seen[v]; !ok {
-				seen[v] = struct{}{}
-				completions = append(completions, v)
-			}
-		}
-		return completions, cobra.ShellCompDirectiveNoFileComp
-	}
-}
-
-// gpuCompletion returns a completion function for the --gpu flag.
-func gpuCompletion(s *state.State) func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
-	return func(cmd *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
-		provider, _ := cmd.Flags().GetString("cloud-provider")
-		if provider == "" {
-			return nil, cobra.ShellCompDirectiveNoFileComp
-		}
-		cpu, _ := cmd.Flags().GetString("cpu")
-		ram, _ := cmd.Flags().GetString("ram")
-		disk, _ := cmd.Flags().GetString("disk")
-		multiAz, _ := cmd.Flags().GetBool("multi-az")
-		pkgs, err := filteredPackages(cmd, s, cpu, ram, disk, "", multiAz)
-		if err != nil {
-			return nil, cobra.ShellCompDirectiveError
-		}
-
-		seen := make(map[string]struct{})
-		var completions []string
-		for _, p := range pkgs {
-			v := p.GetResourceConfiguration().GetGpu()
-			if v == "" {
-				continue
-			}
 			if _, ok := seen[v]; !ok {
 				seen[v] = struct{}{}
 				completions = append(completions, v)

--- a/internal/cmd/cluster/completion_test.go
+++ b/internal/cmd/cluster/completion_test.go
@@ -195,29 +195,6 @@ func TestDiskCompletion_FilteredByCPUAndRAM(t *testing.T) {
 	assert.NotContains(t, stdout, "50GiB")
 }
 
-func TestGPUCompletion(t *testing.T) {
-	env := testutil.NewTestEnv(t)
-
-	env.BookingServer.ListPackagesCalls.Returns(&bookingv1.ListPackagesResponse{
-		Items: []*bookingv1.Package{
-			{Id: "pkg-1", Name: "gpu-small", ResourceConfiguration: &bookingv1.ResourceConfiguration{Cpu: "1000m", Gpu: new("1000m")}},
-			{Id: "pkg-2", Name: "gpu-large", ResourceConfiguration: &bookingv1.ResourceConfiguration{Cpu: "2000m", Gpu: new("2000m")}},
-			{Id: "pkg-3", Name: "cpu-only", ResourceConfiguration: &bookingv1.ResourceConfiguration{Cpu: "500m"}},
-			{Id: "pkg-4", Name: "gpu-dup", ResourceConfiguration: &bookingv1.ResourceConfiguration{Cpu: "4000m", Gpu: new("1000m")}},
-		},
-	}, nil)
-
-	stdout, _, err := testutil.Exec(t, env, "__complete", "cluster", "create", "--cloud-provider", "aws", "--gpu", "")
-	require.NoError(t, err)
-	assert.Contains(t, stdout, "1000m")
-	assert.Contains(t, stdout, "2000m")
-	// Packages without GPU should not appear.
-	assert.NotContains(t, stdout, "500m")
-	// Deduplication: 1000m appears in two packages but once in completions.
-	count := strings.Count(stdout, "1000m")
-	assert.Equal(t, 1, count, "1000m should appear only once")
-}
-
 func TestVersionCompletion_UnavailableExcluded(t *testing.T) {
 	env := testutil.NewTestEnv(t)
 

--- a/internal/cmd/cluster/create.go
+++ b/internal/cmd/cluster/create.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	bookingv1 "github.com/qdrant/qdrant-cloud-public-api/gen/go/qdrant/cloud/booking/v1"
 	clusterv1 "github.com/qdrant/qdrant-cloud-public-api/gen/go/qdrant/cloud/cluster/v1"
 	commonv1 "github.com/qdrant/qdrant-cloud-public-api/gen/go/qdrant/cloud/common/v1"
 
@@ -30,8 +31,7 @@ func newCreateCommand(s *state.State) *cobra.Command {
 			cmd.Flags().String("package", "", "Booking package name or ID (see 'cluster package list')")
 			cmd.Flags().String("cpu", "", "CPU to select a package (e.g. \"1\", \"0.5\", or \"1000m\")")
 			cmd.Flags().String("ram", "", "RAM in GiB to select a package (e.g. \"8\", \"8G\", \"8Gi\", or \"8GiB\")")
-			cmd.Flags().String("disk", "", "Disk size to select a package (e.g. \"100GiB\"); must match a value from 'cluster package list'")
-			cmd.Flags().String("gpu", "", "GPU resource to select a package (e.g. \"1000m\"); must match a value from 'cluster package list'")
+			cmd.Flags().String("disk", "", "Total disk size (e.g. \"200GiB\"); if larger than the package's included disk, the difference is provisioned as additional storage")
 			cmd.Flags().Bool("multi-az", false, "Require a multi-AZ package")
 			cmd.Flags().StringToString("label", nil, "Label to apply to the cluster ('key=value'), can be specified multiple times")
 			cmd.Flags().Bool("wait", false, "Wait for the cluster to become healthy")
@@ -72,7 +72,6 @@ func newCreateCommand(s *state.State) *cobra.Command {
 			cpu, _ := cmd.Flags().GetString("cpu")
 			ram, _ := cmd.Flags().GetString("ram")
 			disk, _ := cmd.Flags().GetString("disk")
-			gpu, _ := cmd.Flags().GetString("gpu")
 			multiAz, _ := cmd.Flags().GetBool("multi-az")
 			labelMap, _ := cmd.Flags().GetStringToString("label")
 
@@ -89,23 +88,31 @@ func newCreateCommand(s *state.State) *cobra.Command {
 				}
 			}
 
-			if packageValue == "" && cpu == "" && ram == "" && disk == "" && gpu == "" {
-				return nil, fmt.Errorf("either --package or at least one of --cpu, --ram, --disk, --gpu is required")
+			if packageValue == "" && cpu == "" && ram == "" {
+				return nil, fmt.Errorf("either --package or --cpu and --ram are required")
 			}
 
+			var pkg *bookingv1.Package
 			var packageID string
+
 			if packageValue != "" {
 				if isUUID(packageValue) {
 					packageID = packageValue
+					if disk != "" {
+						pkg, err = resolvePackageByID(ctx, client.Booking(), accountID, cloudProvider, cloudRegion, packageValue)
+						if err != nil {
+							return nil, err
+						}
+					}
 				} else {
-					pkg, err := resolvePackageByName(ctx, client.Booking(), accountID, cloudProvider, cloudRegion, packageValue)
+					pkg, err = resolvePackageByName(ctx, client.Booking(), accountID, cloudProvider, cloudRegion, packageValue)
 					if err != nil {
 						return nil, err
 					}
 					packageID = pkg.GetId()
 				}
 			} else {
-				pkg, err := resolvePackageByResources(ctx, client.Booking(), accountID, cloudProvider, cloudRegion, cpu, ram, disk, gpu, multiAz)
+				pkg, err = resolvePackageByResources(ctx, client.Booking(), accountID, cloudProvider, cloudRegion, cpu, ram, multiAz)
 				if err != nil {
 					return nil, err
 				}
@@ -129,6 +136,20 @@ func newCreateCommand(s *state.State) *cobra.Command {
 			}
 			for k, v := range labelMap {
 				cluster.Labels = append(cluster.Labels, &commonv1.KeyValue{Key: k, Value: v})
+			}
+
+			if disk != "" && pkg != nil {
+				requestedGiB, err := parseDiskGiB(disk)
+				if err != nil {
+					return nil, fmt.Errorf("invalid --disk value: %w", err)
+				}
+				if pkgDiskStr := pkg.GetResourceConfiguration().GetDisk(); pkgDiskStr != "" {
+					if pkgGiB, err := parseDiskGiB(pkgDiskStr); err == nil && requestedGiB > pkgGiB {
+						cluster.Configuration.AdditionalResources = &clusterv1.AdditionalResources{
+							Disk: requestedGiB - pkgGiB,
+						}
+					}
+				}
 			}
 
 			resp, err := client.Cluster().CreateCluster(ctx, &clusterv1.CreateClusterRequest{
@@ -165,6 +186,5 @@ func newCreateCommand(s *state.State) *cobra.Command {
 	_ = cmd.RegisterFlagCompletionFunc("cpu", cpuCompletion(s))
 	_ = cmd.RegisterFlagCompletionFunc("ram", ramCompletion(s))
 	_ = cmd.RegisterFlagCompletionFunc("disk", diskCompletion(s))
-	_ = cmd.RegisterFlagCompletionFunc("gpu", gpuCompletion(s))
 	return cmd
 }

--- a/internal/cmd/cluster/create_resolve.go
+++ b/internal/cmd/cluster/create_resolve.go
@@ -8,6 +8,21 @@ import (
 	bookingv1 "github.com/qdrant/qdrant-cloud-public-api/gen/go/qdrant/cloud/booking/v1"
 )
 
+// resolvePackageByID fetches a single package by its UUID.
+func resolvePackageByID(ctx context.Context, booking bookingv1.BookingServiceClient,
+	accountID, cloudProvider, cloudRegion, id string) (*bookingv1.Package, error) {
+	resp, err := booking.GetPackage(ctx, &bookingv1.GetPackageRequest{
+		AccountId:             accountID,
+		CloudProviderId:       cloudProvider,
+		CloudProviderRegionId: &cloudRegion,
+		Id:                    id,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get package %s: %w", id, err)
+	}
+	return resp.GetPackage(), nil
+}
+
 // resolvePackageByName lists active packages and returns the first matching by name.
 func resolvePackageByName(ctx context.Context, booking bookingv1.BookingServiceClient,
 	accountID, cloudProvider, cloudRegion, name string) (*bookingv1.Package, error) {
@@ -32,7 +47,7 @@ func resolvePackageByName(ctx context.Context, booking bookingv1.BookingServiceC
 // all non-empty resource dimensions (cpu, ram, disk, gpu) and the multiAz flag.
 // Returns an error if zero or more than one package matches.
 func resolvePackageByResources(ctx context.Context, booking bookingv1.BookingServiceClient,
-	accountID, cloudProvider, cloudRegion, cpu, ram, disk, gpu string, multiAz bool) (*bookingv1.Package, error) {
+	accountID, cloudProvider, cloudRegion, cpu, ram string, multiAz bool) (*bookingv1.Package, error) {
 	req := &bookingv1.ListPackagesRequest{
 		AccountId:             accountID,
 		CloudProviderId:       cloudProvider,
@@ -55,24 +70,18 @@ func resolvePackageByResources(ctx context.Context, booking bookingv1.BookingSer
 		if ram != "" && rc.GetRam() != ram {
 			continue
 		}
-		if disk != "" && rc.GetDisk() != disk {
-			continue
-		}
-		if gpu != "" && rc.GetGpu() != gpu {
-			continue
-		}
 		matches = append(matches, p)
 	}
 	switch len(matches) {
 	case 1:
 		return matches[0], nil
 	case 0:
-		return nil, fmt.Errorf("no package found matching cpu=%q ram=%q disk=%q gpu=%q", cpu, ram, disk, gpu)
+		return nil, fmt.Errorf("no package found matching cpu=%q ram=%q", cpu, ram)
 	default:
 		names := make([]string, len(matches))
 		for i, p := range matches {
 			names[i] = p.GetName()
 		}
-		return nil, fmt.Errorf("multiple packages match cpu=%q ram=%q disk=%q gpu=%q: %s", cpu, ram, disk, gpu, strings.Join(names, ", "))
+		return nil, fmt.Errorf("multiple packages match cpu=%q ram=%q: %s", cpu, ram, strings.Join(names, ", "))
 	}
 }

--- a/internal/cmd/cluster/create_test.go
+++ b/internal/cmd/cluster/create_test.go
@@ -303,6 +303,7 @@ func TestCreateCluster_PackageByResources(t *testing.T) {
 	req, ok := env.Server.CreateClusterCalls.Last()
 	require.True(t, ok)
 	assert.Equal(t, "pkg-res-1", req.GetCluster().GetConfiguration().GetPackageId())
+	assert.Nil(t, req.GetCluster().GetConfiguration().GetAdditionalResources(), "no additional disk expected when requested == package disk")
 }
 
 func TestCreateCluster_PackageByResourcesPartial(t *testing.T) {
@@ -411,48 +412,70 @@ func TestCreateCluster_NoPackageOrResources(t *testing.T) {
 	assert.Contains(t, err.Error(), "--package")
 }
 
-func TestCreateCluster_PackageByGPU(t *testing.T) {
+func TestCreateCluster_AdditionalDisk(t *testing.T) {
 	env := testutil.NewTestEnv(t)
 
-	env.BookingServer.ListPackagesCalls.Returns(&bookingv1.ListPackagesResponse{
-		Items: []*bookingv1.Package{
-			{
-				Id:   "pkg-gpu",
-				Name: "gpu-starter",
-				ResourceConfiguration: &bookingv1.ResourceConfiguration{
-					Cpu:  "2000m",
-					Ram:  "4GiB",
-					Disk: "100GiB",
-					Gpu:  new("1000m"),
-				},
-			},
-			{
-				Id:   "pkg-no-gpu",
-				Name: "cpu-starter",
-				ResourceConfiguration: &bookingv1.ResourceConfiguration{
-					Cpu:  "2000m",
-					Ram:  "4GiB",
-					Disk: "100GiB",
-				},
+	env.BookingServer.GetPackageCalls.Returns(&bookingv1.GetPackageResponse{
+		Package: &bookingv1.Package{
+			Id:   "pkg-100gib",
+			Name: "starter",
+			ResourceConfiguration: &bookingv1.ResourceConfiguration{
+				Cpu:  "1000m",
+				Ram:  "1GiB",
+				Disk: "100GiB",
 			},
 		},
 	}, nil)
 	env.Server.CreateClusterCalls.Returns(&clusterv1.CreateClusterResponse{
-		Cluster: &clusterv1.Cluster{Id: "cluster-gpu"},
+		Cluster: &clusterv1.Cluster{Id: "cluster-extra-disk"},
 	}, nil)
 
 	_, _, err := testutil.Exec(t, env,
 		"cluster", "create",
-		"--name", "gpu-cluster",
+		"--name", "my-cluster",
 		"--cloud-provider", "aws",
 		"--cloud-region", "us-east-1",
-		"--gpu", "1000m",
+		"--package", "550e8400-e29b-41d4-a716-446655440000",
+		"--disk", "200GiB",
 	)
 	require.NoError(t, err)
 
 	req, ok := env.Server.CreateClusterCalls.Last()
 	require.True(t, ok)
-	assert.Equal(t, "pkg-gpu", req.GetCluster().GetConfiguration().GetPackageId())
+	assert.Equal(t, uint32(100), req.GetCluster().GetConfiguration().GetAdditionalResources().GetDisk())
+}
+
+func TestCreateCluster_DiskEqualToPackage(t *testing.T) {
+	env := testutil.NewTestEnv(t)
+
+	env.BookingServer.GetPackageCalls.Returns(&bookingv1.GetPackageResponse{
+		Package: &bookingv1.Package{
+			Id:   "pkg-100gib",
+			Name: "starter",
+			ResourceConfiguration: &bookingv1.ResourceConfiguration{
+				Cpu:  "1000m",
+				Ram:  "1GiB",
+				Disk: "100GiB",
+			},
+		},
+	}, nil)
+	env.Server.CreateClusterCalls.Returns(&clusterv1.CreateClusterResponse{
+		Cluster: &clusterv1.Cluster{Id: "cluster-same-disk"},
+	}, nil)
+
+	_, _, err := testutil.Exec(t, env,
+		"cluster", "create",
+		"--name", "my-cluster",
+		"--cloud-provider", "aws",
+		"--cloud-region", "us-east-1",
+		"--package", "550e8400-e29b-41d4-a716-446655440000",
+		"--disk", "100GiB",
+	)
+	require.NoError(t, err)
+
+	req, ok := env.Server.CreateClusterCalls.Last()
+	require.True(t, ok)
+	assert.Nil(t, req.GetCluster().GetConfiguration().GetAdditionalResources(), "no additional disk when requested == package disk")
 }
 
 func TestCreateCluster_PackageByMultiAZ(t *testing.T) {

--- a/internal/cmd/cluster/resource_normalize.go
+++ b/internal/cmd/cluster/resource_normalize.go
@@ -19,6 +19,32 @@ func normalizeCPU(s string) (string, error) {
 	return fmt.Sprintf("%.0fm", v*1000), nil
 }
 
+// parseDiskGiB parses a disk string to a uint32 GiB value.
+// Accepts "100GiB", "100Gi", "100G", "100" (all → 100),
+// and "1TiB", "1Ti", "1T" (all → 1024).
+func parseDiskGiB(s string) (uint32, error) {
+	for _, suffix := range []string{"TiB", "Ti", "T"} {
+		if strings.HasSuffix(s, suffix) {
+			v, err := strconv.ParseUint(strings.TrimSuffix(s, suffix), 10, 32)
+			if err != nil {
+				return 0, fmt.Errorf("cannot parse %q as a disk value", s)
+			}
+			return uint32(v) * 1024, nil
+		}
+	}
+	for _, suffix := range []string{"GiB", "Gi", "G"} {
+		if strings.HasSuffix(s, suffix) {
+			s = strings.TrimSuffix(s, suffix)
+			break
+		}
+	}
+	v, err := strconv.ParseUint(s, 10, 32)
+	if err != nil {
+		return 0, fmt.Errorf("cannot parse %q as a disk value", s)
+	}
+	return uint32(v), nil
+}
+
 // normalizeRAM converts shorthand RAM values to GiB binary notation.
 // "8" → "8GiB", "8G" → "8GiB", "8Gi" → "8GiB", "8GiB" → "8GiB" (passthrough).
 func normalizeRAM(s string) (string, error) {

--- a/internal/cmd/cluster/resource_normalize_test.go
+++ b/internal/cmd/cluster/resource_normalize_test.go
@@ -37,6 +37,41 @@ func TestNormalizeCPU(t *testing.T) {
 	}
 }
 
+func TestParseDiskGiB(t *testing.T) {
+	tests := []struct {
+		input   string
+		want    uint32
+		wantErr bool
+	}{
+		{"100GiB", 100, false},
+		{"100Gi", 100, false},
+		{"100G", 100, false},
+		{"100", 100, false},
+		{"1TiB", 1024, false},
+		{"1Ti", 1024, false},
+		{"1T", 1024, false},
+		{"2TiB", 2048, false},
+		{"bad", 0, true},
+		{"100X", 0, true},
+	}
+	for _, tt := range tests {
+		got, err := parseDiskGiB(tt.input)
+		if tt.wantErr {
+			if err == nil {
+				t.Errorf("parseDiskGiB(%q): expected error, got %d", tt.input, got)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("parseDiskGiB(%q): unexpected error: %v", tt.input, err)
+			continue
+		}
+		if got != tt.want {
+			t.Errorf("parseDiskGiB(%q) = %d, want %d", tt.input, got, tt.want)
+		}
+	}
+}
+
 func TestNormalizeRAM(t *testing.T) {
 	tests := []struct {
 		input   string

--- a/internal/testutil/fake_booking.go
+++ b/internal/testutil/fake_booking.go
@@ -12,10 +12,17 @@ type FakeBookingService struct {
 	bookingv1.UnimplementedBookingServiceServer
 
 	ListPackagesCalls MethodSpy[*bookingv1.ListPackagesRequest, *bookingv1.ListPackagesResponse]
+	GetPackageCalls   MethodSpy[*bookingv1.GetPackageRequest, *bookingv1.GetPackageResponse]
 }
 
 // ListPackages records the call and dispatches via ListPackagesCalls.
 func (f *FakeBookingService) ListPackages(ctx context.Context, req *bookingv1.ListPackagesRequest) (*bookingv1.ListPackagesResponse, error) {
 	f.ListPackagesCalls.record(req)
 	return f.ListPackagesCalls.dispatch(ctx, req, f.UnimplementedBookingServiceServer.ListPackages)
+}
+
+// GetPackage records the call and dispatches via GetPackageCalls.
+func (f *FakeBookingService) GetPackage(ctx context.Context, req *bookingv1.GetPackageRequest) (*bookingv1.GetPackageResponse, error) {
+	f.GetPackageCalls.record(req)
+	return f.GetPackageCalls.dispatch(ctx, req, f.UnimplementedBookingServiceServer.GetPackage)
 }


### PR DESCRIPTION
Previously, it used cpu, ram, disk and gpu and that's wrong. Disk is customizable by the user and the additional disk on based on the matched package is set on the additional resources field.