### PR TITLE
feat: move cloud-provider and cloud-region subcommands as root commands

### DIFF
--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -6,6 +6,8 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/qdrant/qcloud-cli/internal/cmd/backup"
+	"github.com/qdrant/qcloud-cli/internal/cmd/cloudprovider"
+	"github.com/qdrant/qcloud-cli/internal/cmd/cloudregion"
 	"github.com/qdrant/qcloud-cli/internal/cmd/cluster"
 	cmdcontext "github.com/qdrant/qcloud-cli/internal/cmd/context"
 	"github.com/qdrant/qcloud-cli/internal/cmd/selfupgrade"
@@ -56,6 +58,8 @@ func NewRootCommand(s *state.State) *cobra.Command {
 
 	cmd.AddCommand(version.NewCommand(s))
 	cmd.AddCommand(cluster.NewCommand(s))
+	cmd.AddCommand(cloudprovider.NewCommand(s))
+	cmd.AddCommand(cloudregion.NewCommand(s))
 	cmd.AddCommand(cmdcontext.NewCommand(s))
 	cmd.AddCommand(backup.NewCommand(s))
 	cmd.AddCommand(selfupgrade.NewCommand(s))

--- a/internal/cmd/cloudprovider/cloud_provider.go
+++ b/internal/cmd/cloudprovider/cloud_provider.go
@@ -1,0 +1,18 @@
+package cloudprovider
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/qdrant/qcloud-cli/internal/state"
+)
+
+// NewCommand creates the "cloud-provider" parent command and registers all subcommands.
+func NewCommand(s *state.State) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "cloud-provider",
+		Short: "Manage cloud providers",
+		Args:  cobra.NoArgs,
+	}
+	cmd.AddCommand(newListCommand(s))
+	return cmd
+}

--- a/internal/cmd/cloudprovider/cloud_provider_test.go
+++ b/internal/cmd/cloudprovider/cloud_provider_test.go
@@ -1,4 +1,4 @@
-package cluster_test
+package cloudprovider_test
 
 import (
 	"testing"
@@ -21,7 +21,7 @@ func TestListCloudProviders_TableOutput(t *testing.T) {
 		},
 	}, nil)
 
-	stdout, _, err := testutil.Exec(t, env, "cluster", "cloud-provider", "list")
+	stdout, _, err := testutil.Exec(t, env, "cloud-provider", "list")
 	require.NoError(t, err)
 	assert.Contains(t, stdout, "ID")
 	assert.Contains(t, stdout, "NAME")

--- a/internal/cmd/cloudprovider/list.go
+++ b/internal/cmd/cloudprovider/list.go
@@ -1,4 +1,4 @@
-package cluster
+package cloudprovider
 
 import (
 	"fmt"
@@ -14,17 +14,7 @@ import (
 	"github.com/qdrant/qcloud-cli/internal/state"
 )
 
-func newCloudProviderCommand(s *state.State) *cobra.Command {
-	cmd := &cobra.Command{
-		Use:   "cloud-provider",
-		Short: "Manage cloud providers",
-		Args:  cobra.NoArgs,
-	}
-	cmd.AddCommand(newCloudProviderListCommand(s))
-	return cmd
-}
-
-func newCloudProviderListCommand(s *state.State) *cobra.Command {
+func newListCommand(s *state.State) *cobra.Command {
 	return base.ListCmd[*platformv1.ListCloudProvidersResponse]{
 		Use:   "list",
 		Short: "List available cloud providers",

--- a/internal/cmd/cloudregion/cloud_region.go
+++ b/internal/cmd/cloudregion/cloud_region.go
@@ -1,0 +1,18 @@
+package cloudregion
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/qdrant/qcloud-cli/internal/state"
+)
+
+// NewCommand creates the "cloud-region" parent command and registers all subcommands.
+func NewCommand(s *state.State) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "cloud-region",
+		Short: "Manage cloud regions",
+		Args:  cobra.NoArgs,
+	}
+	cmd.AddCommand(newListCommand(s))
+	return cmd
+}

--- a/internal/cmd/cloudregion/cloud_region_test.go
+++ b/internal/cmd/cloudregion/cloud_region_test.go
@@ -1,4 +1,4 @@
-package cluster_test
+package cloudregion_test
 
 import (
 	"testing"
@@ -14,7 +14,7 @@ import (
 func TestListCloudRegions_RequiresCloudProvider(t *testing.T) {
 	env := testutil.NewTestEnv(t)
 
-	_, _, err := testutil.Exec(t, env, "cluster", "cloud-region", "list")
+	_, _, err := testutil.Exec(t, env, "cloud-region", "list")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "cloud-provider")
 }
@@ -29,7 +29,7 @@ func TestListCloudRegions_TableOutput(t *testing.T) {
 		},
 	}, nil)
 
-	stdout, _, err := testutil.Exec(t, env, "cluster", "cloud-region", "list", "--cloud-provider", "aws")
+	stdout, _, err := testutil.Exec(t, env, "cloud-region", "list", "--cloud-provider", "aws")
 	require.NoError(t, err)
 	assert.Contains(t, stdout, "ID")
 	assert.Contains(t, stdout, "NAME")

--- a/internal/cmd/cloudregion/list.go
+++ b/internal/cmd/cloudregion/list.go
@@ -1,4 +1,4 @@
-package cluster
+package cloudregion
 
 import (
 	"fmt"
@@ -10,21 +10,12 @@ import (
 	platformv1 "github.com/qdrant/qdrant-cloud-public-api/gen/go/qdrant/cloud/platform/v1"
 
 	"github.com/qdrant/qcloud-cli/internal/cmd/base"
+	"github.com/qdrant/qcloud-cli/internal/cmd/completion"
 	"github.com/qdrant/qcloud-cli/internal/cmd/output"
 	"github.com/qdrant/qcloud-cli/internal/state"
 )
 
-func newCloudRegionCommand(s *state.State) *cobra.Command {
-	cmd := &cobra.Command{
-		Use:   "cloud-region",
-		Short: "Manage cloud regions",
-		Args:  cobra.NoArgs,
-	}
-	cmd.AddCommand(newCloudRegionListCommand(s))
-	return cmd
-}
-
-func newCloudRegionListCommand(s *state.State) *cobra.Command {
+func newListCommand(s *state.State) *cobra.Command {
 	cmd := base.ListCmd[*platformv1.ListCloudProviderRegionsResponse]{
 		Use:   "list",
 		Short: "List available cloud regions for a cloud provider",
@@ -73,5 +64,6 @@ func newCloudRegionListCommand(s *state.State) *cobra.Command {
 
 	cmd.Flags().String("cloud-provider", "", "Cloud provider ID (required)")
 	_ = cmd.MarkFlagRequired("cloud-provider")
+	_ = cmd.RegisterFlagCompletionFunc("cloud-provider", completion.CloudProviderCompletion(s))
 	return cmd
 }

--- a/internal/cmd/cluster/cluster.go
+++ b/internal/cmd/cluster/cluster.go
@@ -25,8 +25,6 @@ func NewCommand(s *state.State) *cobra.Command {
 		newWaitCommand(s),
 		newVersionCommand(s),
 		newPackageCommand(s),
-		newCloudProviderCommand(s),
-		newCloudRegionCommand(s),
 		newKeyCommand(s),
 	)
 	return cmd

--- a/internal/cmd/cluster/completion.go
+++ b/internal/cmd/cluster/completion.go
@@ -7,74 +7,9 @@ import (
 
 	bookingv1 "github.com/qdrant/qdrant-cloud-public-api/gen/go/qdrant/cloud/booking/v1"
 	clusterv1 "github.com/qdrant/qdrant-cloud-public-api/gen/go/qdrant/cloud/cluster/v1"
-	platformv1 "github.com/qdrant/qdrant-cloud-public-api/gen/go/qdrant/cloud/platform/v1"
 
 	"github.com/qdrant/qcloud-cli/internal/state"
 )
-
-// cloudProviderCompletion returns a completion function for the --cloud-provider flag.
-func cloudProviderCompletion(s *state.State) func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
-	return func(cmd *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
-		ctx := cmd.Context()
-		client, err := s.Client(ctx)
-		if err != nil {
-			return nil, cobra.ShellCompDirectiveError
-		}
-
-		accountID, err := s.AccountID()
-		if err != nil {
-			return nil, cobra.ShellCompDirectiveError
-		}
-
-		resp, err := client.Platform().ListCloudProviders(ctx, &platformv1.ListCloudProvidersRequest{
-			AccountId: accountID,
-		})
-		if err != nil {
-			return nil, cobra.ShellCompDirectiveError
-		}
-
-		completions := make([]string, 0, len(resp.GetItems()))
-		for _, p := range resp.GetItems() {
-			completions = append(completions, p.GetId()+"\t"+p.GetName())
-		}
-		return completions, cobra.ShellCompDirectiveNoFileComp
-	}
-}
-
-// cloudRegionCompletion returns a completion function for the --cloud-region flag.
-func cloudRegionCompletion(s *state.State) func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
-	return func(cmd *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
-		provider, _ := cmd.Flags().GetString("cloud-provider")
-		if provider == "" {
-			return nil, cobra.ShellCompDirectiveNoFileComp
-		}
-
-		ctx := cmd.Context()
-		client, err := s.Client(ctx)
-		if err != nil {
-			return nil, cobra.ShellCompDirectiveError
-		}
-
-		accountID, err := s.AccountID()
-		if err != nil {
-			return nil, cobra.ShellCompDirectiveError
-		}
-
-		resp, err := client.Platform().ListCloudProviderRegions(ctx, &platformv1.ListCloudProviderRegionsRequest{
-			AccountId:       accountID,
-			CloudProviderId: provider,
-		})
-		if err != nil {
-			return nil, cobra.ShellCompDirectiveError
-		}
-
-		completions := make([]string, 0, len(resp.GetItems()))
-		for _, r := range resp.GetItems() {
-			completions = append(completions, r.GetId()+"\t"+r.GetName())
-		}
-		return completions, cobra.ShellCompDirectiveNoFileComp
-	}
-}
 
 // versionCompletion returns a completion function for the --version flag.
 func versionCompletion(s *state.State) func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {

--- a/internal/cmd/cluster/create.go
+++ b/internal/cmd/cluster/create.go
@@ -12,6 +12,7 @@ import (
 	commonv1 "github.com/qdrant/qdrant-cloud-public-api/gen/go/qdrant/cloud/common/v1"
 
 	"github.com/qdrant/qcloud-cli/internal/cmd/base"
+	"github.com/qdrant/qcloud-cli/internal/cmd/completion"
 	"github.com/qdrant/qcloud-cli/internal/state"
 )
 
@@ -187,8 +188,8 @@ func newCreateCommand(s *state.State) *cobra.Command {
 			}
 		},
 	}.CobraCommand(s)
-	_ = cmd.RegisterFlagCompletionFunc("cloud-provider", cloudProviderCompletion(s))
-	_ = cmd.RegisterFlagCompletionFunc("cloud-region", cloudRegionCompletion(s))
+	_ = cmd.RegisterFlagCompletionFunc("cloud-provider", completion.CloudProviderCompletion(s))
+	_ = cmd.RegisterFlagCompletionFunc("cloud-region", completion.CloudRegionCompletion(s))
 	_ = cmd.RegisterFlagCompletionFunc("package", packageCompletion(s))
 	_ = cmd.RegisterFlagCompletionFunc("version", versionCompletion(s))
 	_ = cmd.RegisterFlagCompletionFunc("cpu", cpuCompletion(s))

--- a/internal/cmd/cluster/list.go
+++ b/internal/cmd/cluster/list.go
@@ -9,6 +9,7 @@ import (
 	clusterv1 "github.com/qdrant/qdrant-cloud-public-api/gen/go/qdrant/cloud/cluster/v1"
 
 	"github.com/qdrant/qcloud-cli/internal/cmd/base"
+	"github.com/qdrant/qcloud-cli/internal/cmd/completion"
 	"github.com/qdrant/qcloud-cli/internal/cmd/output"
 	"github.com/qdrant/qcloud-cli/internal/state"
 )
@@ -150,8 +151,8 @@ Use --cloud-provider and --cloud-region to filter results server-side:
 	cmd.Flags().String("cloud-provider", "", "Filter by cloud provider ID")
 	cmd.Flags().String("cloud-region", "", "Filter by cloud provider region ID")
 
-	_ = cmd.RegisterFlagCompletionFunc("cloud-provider", cloudProviderCompletion(s))
-	_ = cmd.RegisterFlagCompletionFunc("cloud-region", cloudRegionCompletion(s))
+	_ = cmd.RegisterFlagCompletionFunc("cloud-provider", completion.CloudProviderCompletion(s))
+	_ = cmd.RegisterFlagCompletionFunc("cloud-region", completion.CloudRegionCompletion(s))
 
 	return cmd
 }

--- a/internal/cmd/completion/completion.go
+++ b/internal/cmd/completion/completion.go
@@ -5,9 +5,74 @@ import (
 
 	backupv1 "github.com/qdrant/qdrant-cloud-public-api/gen/go/qdrant/cloud/cluster/backup/v1"
 	clusterv1 "github.com/qdrant/qdrant-cloud-public-api/gen/go/qdrant/cloud/cluster/v1"
+	platformv1 "github.com/qdrant/qdrant-cloud-public-api/gen/go/qdrant/cloud/platform/v1"
 
 	"github.com/qdrant/qcloud-cli/internal/state"
 )
+
+// CloudProviderCompletion returns a completion function for the --cloud-provider flag.
+func CloudProviderCompletion(s *state.State) func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
+	return func(cmd *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+		ctx := cmd.Context()
+		client, err := s.Client(ctx)
+		if err != nil {
+			return nil, cobra.ShellCompDirectiveError
+		}
+
+		accountID, err := s.AccountID()
+		if err != nil {
+			return nil, cobra.ShellCompDirectiveError
+		}
+
+		resp, err := client.Platform().ListCloudProviders(ctx, &platformv1.ListCloudProvidersRequest{
+			AccountId: accountID,
+		})
+		if err != nil {
+			return nil, cobra.ShellCompDirectiveError
+		}
+
+		completions := make([]string, 0, len(resp.GetItems()))
+		for _, p := range resp.GetItems() {
+			completions = append(completions, p.GetId()+"\t"+p.GetName())
+		}
+		return completions, cobra.ShellCompDirectiveNoFileComp
+	}
+}
+
+// CloudRegionCompletion returns a completion function for the --cloud-region flag.
+func CloudRegionCompletion(s *state.State) func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
+	return func(cmd *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+		provider, _ := cmd.Flags().GetString("cloud-provider")
+		if provider == "" {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+
+		ctx := cmd.Context()
+		client, err := s.Client(ctx)
+		if err != nil {
+			return nil, cobra.ShellCompDirectiveError
+		}
+
+		accountID, err := s.AccountID()
+		if err != nil {
+			return nil, cobra.ShellCompDirectiveError
+		}
+
+		resp, err := client.Platform().ListCloudProviderRegions(ctx, &platformv1.ListCloudProviderRegionsRequest{
+			AccountId:       accountID,
+			CloudProviderId: provider,
+		})
+		if err != nil {
+			return nil, cobra.ShellCompDirectiveError
+		}
+
+		completions := make([]string, 0, len(resp.GetItems()))
+		for _, r := range resp.GetItems() {
+			completions = append(completions, r.GetId()+"\t"+r.GetName())
+		}
+		return completions, cobra.ShellCompDirectiveNoFileComp
+	}
+}
 
 // BackupIDCompletion returns a ValidArgsFunction that completes backup IDs.
 func BackupIDCompletion(s *state.State) func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {


### PR DESCRIPTION
It makes more sense this way, as those are not dependant on clusters existing