### PR TITLE
feat: cluster scale command

### DIFF
--- a/internal/cmd/cluster/cluster.go
+++ b/internal/cmd/cluster/cluster.go
@@ -26,6 +26,7 @@ func NewCommand(s *state.State) *cobra.Command {
 		newVersionCommand(s),
 		newPackageCommand(s),
 		newKeyCommand(s),
+		newScaleCommand(s),
 	)
 	return cmd
 }

--- a/internal/cmd/cluster/scale.go
+++ b/internal/cmd/cluster/scale.go
@@ -1,6 +1,7 @@
 package cluster
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"time"
@@ -26,7 +27,7 @@ func newScaleCommand(s *state.State) *cobra.Command {
 				Long:  "Scales the resources of a cluster",
 				Args:  util.ExactArgs(1, "a cluster ID"),
 			}
-			cmd.Flags().Uint32("nodes", 1, "Number of nodes (default 1)")
+			cmd.Flags().Uint32("nodes", 0, "Number of nodes")
 			cmd.Flags().BoolP("force", "f", false, "Skip confirmation prompts")
 			cmd.Flags().Var(new(resource.Millicores), "cpu", "CPU to select a package (e.g. \"1\", \"0.5\", or \"1000m\")")
 			cmd.Flags().Var(new(resource.ByteQuantity), "ram", "RAM to select a package (e.g. \"8\", \"8G\", \"8Gi\", or \"8GiB\")")
@@ -121,24 +122,31 @@ func newScaleCommand(s *state.State) *cobra.Command {
 				return nil, err
 			}
 
-			// scale doesn't allow changing multi-az so any new package selected needs to
-			// use the same multi-az value
-			newPkg, err := resolvePackageByResources(
-				ctx,
-				client.Booking(),
-				accountID,
-				cluster.CloudProviderId,
-				cluster.CloudProviderRegionId,
-				cpu,
-				gpu,
-				ram,
-				currentPkg.GetPackage().GetMultiAz(),
-			)
-			if err != nil {
-				return nil, err
+			// If no resource flags changed, keep the current package — avoids a
+			// ListPackages round-trip and prevents spurious failures when the current
+			// package is deprecated or shares specs with another active package.
+			var newPkg *bookingv1.Package
+			if cmd.Flags().Changed("cpu") || cmd.Flags().Changed("ram") || cmd.Flags().Changed("gpu") {
+				// scale doesn't allow changing multi-az so any new package selected needs to
+				// use the same multi-az value
+				newPkg, err = resolvePackageByResources(
+					ctx,
+					client.Booking(),
+					accountID,
+					cluster.CloudProviderId,
+					cluster.CloudProviderRegionId,
+					cpu,
+					gpu,
+					ram,
+					currentPkg.GetPackage().GetMultiAz(),
+				)
+				if err != nil {
+					return nil, err
+				}
+				cluster.Configuration.PackageId = newPkg.Id
+			} else {
+				newPkg = currentPkg.GetPackage()
 			}
-
-			cluster.Configuration.PackageId = newPkg.Id
 
 			// disk handling
 			newPkgDisk, err := resource.ParseByteQuantity(newPkg.GetResourceConfiguration().GetDisk())
@@ -188,6 +196,10 @@ func newScaleCommand(s *state.State) *cobra.Command {
 					return nil, err
 				}
 
+				if nodes == 0 {
+					return nil, errors.New("nodes can't be downscaled to 0")
+				}
+
 				cluster.Configuration.NumberOfNodes = nodes
 			}
 
@@ -223,12 +235,12 @@ func newScaleCommand(s *state.State) *cobra.Command {
 			pollInterval, _ := cmd.Flags().GetDuration("wait-poll-interval")
 			fmt.Fprintf(cmd.ErrOrStderr(), "Scaling Cluster %s (%s)...\n", resp.GetCluster().GetId(), resp.GetCluster().GetName())
 			return waitForHealthyWithInterval(
-				ctx, 
-				client.Cluster(), 
-				cmd.ErrOrStderr(), 
-				accountID, 
-				resp.GetCluster().GetId(), 
-				waitTimeout, 
+				ctx,
+				client.Cluster(),
+				cmd.ErrOrStderr(),
+				accountID,
+				resp.GetCluster().GetId(),
+				waitTimeout,
 				pollInterval,
 			)
 		},

--- a/internal/cmd/cluster/scale.go
+++ b/internal/cmd/cluster/scale.go
@@ -5,14 +5,16 @@ import (
 	"io"
 	"time"
 
+	"github.com/spf13/cobra"
+
+	bookingv1 "github.com/qdrant/qdrant-cloud-public-api/gen/go/qdrant/cloud/booking/v1"
+	clusterv1 "github.com/qdrant/qdrant-cloud-public-api/gen/go/qdrant/cloud/cluster/v1"
+
 	"github.com/qdrant/qcloud-cli/internal/cmd/base"
 	"github.com/qdrant/qcloud-cli/internal/cmd/completion"
 	"github.com/qdrant/qcloud-cli/internal/cmd/util"
 	"github.com/qdrant/qcloud-cli/internal/resource"
 	"github.com/qdrant/qcloud-cli/internal/state"
-	bookingv1 "github.com/qdrant/qdrant-cloud-public-api/gen/go/qdrant/cloud/booking/v1"
-	clusterv1 "github.com/qdrant/qdrant-cloud-public-api/gen/go/qdrant/cloud/cluster/v1"
-	"github.com/spf13/cobra"
 )
 
 func newScaleCommand(s *state.State) *cobra.Command {
@@ -25,6 +27,7 @@ func newScaleCommand(s *state.State) *cobra.Command {
 				Args:  util.ExactArgs(1, "a cluster ID"),
 			}
 			cmd.Flags().Uint32("nodes", 1, "Number of nodes (default 1)")
+			cmd.Flags().BoolP("force", "f", false, "Skip confirmation prompts")
 			cmd.Flags().Var(new(resource.Millicores), "cpu", "CPU to select a package (e.g. \"1\", \"0.5\", or \"1000m\")")
 			cmd.Flags().Var(new(resource.ByteQuantity), "ram", "RAM to select a package (e.g. \"8\", \"8G\", \"8Gi\", or \"8GiB\")")
 			cmd.Flags().Var(new(resource.ByteQuantity), "disk", "Total disk size (e.g. \"200GiB\"); if larger than the package's included disk, the difference is provisioned as additional storage")
@@ -143,39 +146,42 @@ func newScaleCommand(s *state.State) *cobra.Command {
 				return nil, err
 			}
 
-			currentAdditionalDisk := resource.ByteQuantity(cluster.Configuration.AdditionalResources.GetDisk() * uint32(resource.GiB))
+			currentAdditionalDisk := resource.ByteQuantity(int64(cluster.Configuration.AdditionalResources.GetDisk()) * int64(resource.GiB))
 			currentTotalDisk := currentPkgDisk + currentAdditionalDisk
 
+			// If a new package is selected from user changes and the user changes the disk too
+			// but it's smaller than the new packages' minimum disk value, it will be overriden.
+			// This is used to notify the user about it.
+			diskWillBeOverridden := false
+			var newEffectiveDisk resource.ByteQuantity
+			var requestedDisk resource.ByteQuantity
 			if cmd.Flags().Changed("disk") {
-				disk := *cmd.Flags().Lookup("disk").Value.(*resource.ByteQuantity)
+				requestedDisk = *cmd.Flags().Lookup("disk").Value.(*resource.ByteQuantity)
+				newEffectiveDisk = max(requestedDisk, newPkgDisk)
+				if newEffectiveDisk < currentTotalDisk {
+					return nil, fmt.Errorf("disk cannot be downscaled from %s to %s", currentTotalDisk, requestedDisk)
+				}
+
 				// only apply additional disk calculation if requested disk is bigger than the disk package
 				// if disk is less than the package disk, let the api fail
-				if disk > newPkgDisk {
-					cluster.Configuration.AdditionalResources = &clusterv1.AdditionalResources{
-						Disk: uint32(disk.GiB() - newPkgDisk.GiB()),
-					}
-				} else {
-					// zero out additional disk in case the cluster had it
-					cluster.Configuration.AdditionalResources = &clusterv1.AdditionalResources{
-						Disk: 0, 
-					}
+				cluster.Configuration.AdditionalResources = &clusterv1.AdditionalResources{
+					Disk: uint32(newEffectiveDisk.GiB() - newPkgDisk.GiB()),
+				}
+
+				if requestedDisk < newEffectiveDisk {
+					diskWillBeOverridden = true
 				}
 			} else {
-				// if the resolved package has less disk than the current one, calculate the difference
-				// as disk additional resource. The API does not allow downscaling disk space.
-				if newPkgDisk < currentTotalDisk {
-					cluster.Configuration.AdditionalResources = &clusterv1.AdditionalResources{
-						Disk: uint32(currentTotalDisk.GiB() - newPkgDisk.GiB()),
-					}
-				} else {
-					// zero out additional disk in case the package already covers previous disk size
-					cluster.Configuration.AdditionalResources = &clusterv1.AdditionalResources{
-						Disk: 0, 
-					}
+				// at this point the user didn't request a disk value but a package change could
+				// make the disk change.
+				newEffectiveDisk = max(currentTotalDisk, newPkgDisk)
+
+				cluster.Configuration.AdditionalResources = &clusterv1.AdditionalResources{
+					Disk: uint32(newEffectiveDisk.GiB() - newPkgDisk.GiB()),
 				}
 			}
 
-
+			oldNodes := cluster.Configuration.NumberOfNodes
 			if cmd.Flags().Changed("nodes") {
 				nodes, err := cmd.Flags().GetUint32("nodes")
 				if err != nil {
@@ -183,6 +189,22 @@ func newScaleCommand(s *state.State) *cobra.Command {
 				}
 
 				cluster.Configuration.NumberOfNodes = nodes
+			}
+
+			force, _ := cmd.Flags().GetBool("force")
+			prompt := scaleConfirmPrompt(
+				cluster,
+				currentPkg.GetPackage(),
+				newPkg,
+				oldNodes,
+				currentTotalDisk,
+				newEffectiveDisk,
+				requestedDisk,
+				diskWillBeOverridden,
+			)
+			if !util.ConfirmAction(force, prompt) {
+				fmt.Fprintln(cmd.OutOrStdout(), "Aborted.")
+				return nil, nil
 			}
 
 			resp, err := client.Cluster().UpdateCluster(ctx, &clusterv1.UpdateClusterRequest{
@@ -200,9 +222,20 @@ func newScaleCommand(s *state.State) *cobra.Command {
 			waitTimeout, _ := cmd.Flags().GetDuration("wait-timeout")
 			pollInterval, _ := cmd.Flags().GetDuration("wait-poll-interval")
 			fmt.Fprintf(cmd.ErrOrStderr(), "Scaling Cluster %s (%s)...\n", resp.GetCluster().GetId(), resp.GetCluster().GetName())
-			return waitForHealthyWithInterval(ctx, client.Cluster(), cmd.ErrOrStderr(), accountID, resp.GetCluster().GetId(), waitTimeout, pollInterval)
+			return waitForHealthyWithInterval(
+				ctx, 
+				client.Cluster(), 
+				cmd.ErrOrStderr(), 
+				accountID, 
+				resp.GetCluster().GetId(), 
+				waitTimeout, 
+				pollInterval,
+			)
 		},
 		PrintResource: func(_ *cobra.Command, out io.Writer, updated *clusterv1.Cluster) {
+			if updated == nil {
+				return
+			}
 			if updated.State.Phase != clusterv1.ClusterPhase_CLUSTER_PHASE_HEALTHY {
 				fmt.Fprintf(out, "Cluster %s (%s) is scaling, it will take some time to take effect. Use 'cluster wait %s' to wait for it to become healthy\n", updated.GetId(), updated.GetName(), updated.GetId())
 				return
@@ -217,4 +250,44 @@ func newScaleCommand(s *state.State) *cobra.Command {
 	_ = cmd.RegisterFlagCompletionFunc("disk", diskCompletion(s))
 	_ = cmd.RegisterFlagCompletionFunc("gpu", gpuCompletion(s))
 	return cmd
+}
+
+// scaleDiff formats a field value as "old => new" when the value changes, or just "val" when unchanged.
+func scaleDiff(oldVal, newVal string) string {
+	if oldVal == newVal {
+		return newVal
+	}
+	return oldVal + " => " + newVal
+}
+
+// scaleConfirmPrompt builds the confirmation message shown before a scale operation,
+// displaying old => new for fields that are changing.
+func scaleConfirmPrompt(
+	cluster *clusterv1.Cluster,
+	oldPkg, newPkg *bookingv1.Package,
+	oldNodes uint32,
+	currentTotalDisk, newEffectiveDisk, requestedDisk resource.ByteQuantity,
+	diskWillBeOverridden bool,
+) string {
+	oldRC := oldPkg.GetResourceConfiguration()
+	newRC := newPkg.GetResourceConfiguration()
+
+	diskLine := scaleDiff(currentTotalDisk.String(), newEffectiveDisk.String())
+	if diskWillBeOverridden {
+		diskLine = fmt.Sprintf("%s (requested: %s - package minimum disk is being applied)", scaleDiff(currentTotalDisk.String(), newEffectiveDisk.String()), requestedDisk)
+	}
+
+	prompt := fmt.Sprintf(
+		"Cluster %s (%s) will be scaled to:\n  Nodes:   %s\n  CPU:     %s\n  RAM:     %s\n  Disk:    %s",
+		cluster.GetId(), cluster.GetName(),
+		scaleDiff(fmt.Sprintf("%d", oldNodes), fmt.Sprintf("%d", cluster.Configuration.NumberOfNodes)),
+		scaleDiff(oldRC.GetCpu(), newRC.GetCpu()),
+		scaleDiff(oldRC.GetRam(), newRC.GetRam()),
+		diskLine,
+	)
+	if oldRC.GetGpu() != "" || newRC.GetGpu() != "" {
+		prompt += fmt.Sprintf("\n  GPU:     %s", scaleDiff(oldRC.GetGpu(), newRC.GetGpu()))
+	}
+	prompt += "\nProceed?"
+	return prompt
 }

--- a/internal/cmd/cluster/scale.go
+++ b/internal/cmd/cluster/scale.go
@@ -1,0 +1,220 @@
+package cluster
+
+import (
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/qdrant/qcloud-cli/internal/cmd/base"
+	"github.com/qdrant/qcloud-cli/internal/cmd/completion"
+	"github.com/qdrant/qcloud-cli/internal/cmd/util"
+	"github.com/qdrant/qcloud-cli/internal/resource"
+	"github.com/qdrant/qcloud-cli/internal/state"
+	bookingv1 "github.com/qdrant/qdrant-cloud-public-api/gen/go/qdrant/cloud/booking/v1"
+	clusterv1 "github.com/qdrant/qdrant-cloud-public-api/gen/go/qdrant/cloud/cluster/v1"
+	"github.com/spf13/cobra"
+)
+
+func newScaleCommand(s *state.State) *cobra.Command {
+	cmd := base.UpdateCmd[*clusterv1.Cluster]{
+		BaseCobraCommand: func() *cobra.Command {
+			cmd := &cobra.Command{
+				Use:   "scale <cluster-id>",
+				Short: "Scales the resources of a cluster",
+				Long:  "Scales the resources of a cluster",
+				Args:  util.ExactArgs(1, "a cluster ID"),
+			}
+			cmd.Flags().Uint32("nodes", 1, "Number of nodes (default 1)")
+			cmd.Flags().Var(new(resource.Millicores), "cpu", "CPU to select a package (e.g. \"1\", \"0.5\", or \"1000m\")")
+			cmd.Flags().Var(new(resource.ByteQuantity), "ram", "RAM to select a package (e.g. \"8\", \"8G\", \"8Gi\", or \"8GiB\")")
+			cmd.Flags().Var(new(resource.ByteQuantity), "disk", "Total disk size (e.g. \"200GiB\"); if larger than the package's included disk, the difference is provisioned as additional storage")
+			cmd.Flags().Var(new(resource.Millicores), "gpu", "Number of GPUs to select a package (e.g. \"1\", \"2\", or \"1000m\")")
+			cmd.Flags().Bool("wait", false, "Wait for the cluster to become healthy")
+			cmd.Flags().Duration("wait-timeout", 10*time.Minute, "Maximum time to wait for cluster health")
+			cmd.Flags().Duration("wait-poll-interval", 5*time.Second, "How often to poll for cluster health")
+			_ = cmd.Flags().MarkHidden("wait-poll-interval")
+			return cmd
+		},
+		Fetch: func(s *state.State, cmd *cobra.Command, args []string) (*clusterv1.Cluster, error) {
+			ctx := cmd.Context()
+			client, err := s.Client(ctx)
+			if err != nil {
+				return nil, err
+			}
+
+			accountID, err := s.AccountID()
+			if err != nil {
+				return nil, err
+			}
+
+			resp, err := client.Cluster().GetCluster(ctx, &clusterv1.GetClusterRequest{
+				ClusterId: args[0],
+				AccountId: accountID,
+			})
+			if err != nil {
+				return nil, fmt.Errorf("failed to get cluster: %w", err)
+			}
+
+			return resp.GetCluster(), nil
+		},
+		Update: func(s *state.State, cmd *cobra.Command, cluster *clusterv1.Cluster) (*clusterv1.Cluster, error) {
+			ctx := cmd.Context()
+			client, err := s.Client(ctx)
+			if err != nil {
+				return nil, err
+			}
+
+			accountID, err := s.AccountID()
+			if err != nil {
+				return nil, err
+			}
+
+			currentPkg, err := client.Booking().GetPackage(ctx, &bookingv1.GetPackageRequest{
+				AccountId:             accountID,
+				Id:                    cluster.Configuration.PackageId,
+				CloudProviderId:       cluster.CloudProviderId,
+				CloudProviderRegionId: &cluster.CloudProviderRegionId,
+			})
+			if err != nil {
+				return nil, err
+			}
+
+			// the new package has to match current values when they are not changed by the user
+			// so if the flags are present set them, else grab the values from the current package
+			var cpu resource.Millicores
+			var ram resource.ByteQuantity
+			var gpu resource.Millicores
+			if cmd.Flags().Changed("cpu") {
+				cpu = *cmd.Flags().Lookup("cpu").Value.(*resource.Millicores)
+			} else {
+				cpu, err = resource.ParseMillicores(currentPkg.GetPackage().GetResourceConfiguration().GetCpu())
+				if err != nil {
+					return nil, err
+				}
+			}
+
+			if cmd.Flags().Changed("ram") {
+				ram = *cmd.Flags().Lookup("ram").Value.(*resource.ByteQuantity)
+			} else {
+				ram, err = resource.ParseByteQuantity(currentPkg.GetPackage().GetResourceConfiguration().GetRam())
+				if err != nil {
+					return nil, err
+				}
+			}
+
+			if cmd.Flags().Changed("gpu") {
+				gpu = *cmd.Flags().Lookup("gpu").Value.(*resource.Millicores)
+			} else {
+				if currentPkg.GetPackage().GetResourceConfiguration().GetGpu() != "" {
+					gpu, err = resource.ParseMillicores(currentPkg.GetPackage().GetResourceConfiguration().GetGpu())
+					if err != nil {
+						return nil, err
+					}
+				}
+			}
+
+			currentPkgDisk, err := resource.ParseByteQuantity(currentPkg.GetPackage().GetResourceConfiguration().GetDisk())
+			if err != nil {
+				return nil, err
+			}
+
+			// scale doesn't allow changing multi-az so any new package selected needs to
+			// use the same multi-az value
+			newPkg, err := resolvePackageByResources(
+				ctx,
+				client.Booking(),
+				accountID,
+				cluster.CloudProviderId,
+				cluster.CloudProviderRegionId,
+				cpu,
+				gpu,
+				ram,
+				currentPkg.GetPackage().GetMultiAz(),
+			)
+			if err != nil {
+				return nil, err
+			}
+
+			cluster.Configuration.PackageId = newPkg.Id
+
+			// disk handling
+			newPkgDisk, err := resource.ParseByteQuantity(newPkg.GetResourceConfiguration().GetDisk())
+			if err != nil {
+				return nil, err
+			}
+
+			currentAdditionalDisk := resource.ByteQuantity(cluster.Configuration.AdditionalResources.GetDisk() * uint32(resource.GiB))
+			currentTotalDisk := currentPkgDisk + currentAdditionalDisk
+
+			if cmd.Flags().Changed("disk") {
+				disk := *cmd.Flags().Lookup("disk").Value.(*resource.ByteQuantity)
+				// only apply additional disk calculation if requested disk is bigger than the disk package
+				// if disk is less than the package disk, let the api fail
+				if disk > newPkgDisk {
+					cluster.Configuration.AdditionalResources = &clusterv1.AdditionalResources{
+						Disk: uint32(disk.GiB() - newPkgDisk.GiB()),
+					}
+				} else {
+					// zero out additional disk in case the cluster had it
+					cluster.Configuration.AdditionalResources = &clusterv1.AdditionalResources{
+						Disk: 0, 
+					}
+				}
+			} else {
+				// if the resolved package has less disk than the current one, calculate the difference
+				// as disk additional resource. The API does not allow downscaling disk space.
+				if newPkgDisk < currentTotalDisk {
+					cluster.Configuration.AdditionalResources = &clusterv1.AdditionalResources{
+						Disk: uint32(currentTotalDisk.GiB() - newPkgDisk.GiB()),
+					}
+				} else {
+					// zero out additional disk in case the package already covers previous disk size
+					cluster.Configuration.AdditionalResources = &clusterv1.AdditionalResources{
+						Disk: 0, 
+					}
+				}
+			}
+
+
+			if cmd.Flags().Changed("nodes") {
+				nodes, err := cmd.Flags().GetUint32("nodes")
+				if err != nil {
+					return nil, err
+				}
+
+				cluster.Configuration.NumberOfNodes = nodes
+			}
+
+			resp, err := client.Cluster().UpdateCluster(ctx, &clusterv1.UpdateClusterRequest{
+				Cluster: cluster,
+			})
+			if err != nil {
+				return nil, fmt.Errorf("failed to update cluster: %w", err)
+			}
+
+			wait, _ := cmd.Flags().GetBool("wait")
+			if !wait {
+				return resp.GetCluster(), nil
+			}
+
+			waitTimeout, _ := cmd.Flags().GetDuration("wait-timeout")
+			pollInterval, _ := cmd.Flags().GetDuration("wait-poll-interval")
+			fmt.Fprintf(cmd.ErrOrStderr(), "Scaling Cluster %s (%s)...\n", resp.GetCluster().GetId(), resp.GetCluster().GetName())
+			return waitForHealthyWithInterval(ctx, client.Cluster(), cmd.ErrOrStderr(), accountID, resp.GetCluster().GetId(), waitTimeout, pollInterval)
+		},
+		PrintResource: func(_ *cobra.Command, out io.Writer, updated *clusterv1.Cluster) {
+			if updated.State.Phase != clusterv1.ClusterPhase_CLUSTER_PHASE_HEALTHY {
+				fmt.Fprintf(out, "Cluster %s (%s) is scaling, it will take some time to take effect. Use 'cluster wait %s' to wait for it to become healthy\n", updated.GetId(), updated.GetName(), updated.GetId())
+				return
+			}
+			fmt.Fprintf(out, "Cluster %s (%s) scaled successfully.\n", updated.GetId(), updated.GetName())
+		},
+		ValidArgsFunction: completion.ClusterIDCompletion(s),
+	}.CobraCommand(s)
+
+	_ = cmd.RegisterFlagCompletionFunc("cpu", cpuCompletion(s))
+	_ = cmd.RegisterFlagCompletionFunc("ram", ramCompletion(s))
+	_ = cmd.RegisterFlagCompletionFunc("disk", diskCompletion(s))
+	_ = cmd.RegisterFlagCompletionFunc("gpu", gpuCompletion(s))
+	return cmd
+}

--- a/internal/cmd/cluster/scale_test.go
+++ b/internal/cmd/cluster/scale_test.go
@@ -1,0 +1,1 @@
+package cluster_test

--- a/internal/cmd/cluster/scale_test.go
+++ b/internal/cmd/cluster/scale_test.go
@@ -1,1 +1,454 @@
 package cluster_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	bookingv1 "github.com/qdrant/qdrant-cloud-public-api/gen/go/qdrant/cloud/booking/v1"
+	clusterv1 "github.com/qdrant/qdrant-cloud-public-api/gen/go/qdrant/cloud/cluster/v1"
+
+	"github.com/qdrant/qcloud-cli/internal/testutil"
+)
+
+const (
+	pkgID1 = "00000000-0000-0000-0000-000000000001"
+	pkgID2 = "00000000-0000-0000-0000-000000000002"
+	pkgID3 = "00000000-0000-0000-0000-000000000003"
+	pkgID4 = "00000000-0000-0000-0000-000000000004"
+	pkgIDA = "00000000-0000-0000-0000-0000000000AA"
+	pkgIDB = "00000000-0000-0000-0000-0000000000BB"
+)
+
+func baseCluster() *clusterv1.Cluster {
+	return &clusterv1.Cluster{
+		Id:                    "cluster-123",
+		Name:                  "test-cluster",
+		CloudProviderId:       "aws",
+		CloudProviderRegionId: "us-east-1",
+		Configuration: &clusterv1.ClusterConfiguration{
+			PackageId:           pkgID1,
+			NumberOfNodes:       1,
+			AdditionalResources: &clusterv1.AdditionalResources{Disk: 0},
+		},
+		State: &clusterv1.ClusterState{
+			Phase: clusterv1.ClusterPhase_CLUSTER_PHASE_HEALTHY,
+		},
+	}
+}
+
+func scalePkg(id, cpu, ram, disk string) *bookingv1.Package {
+	return &bookingv1.Package{
+		Id:   id,
+		Name: id,
+		ResourceConfiguration: &bookingv1.ResourceConfiguration{
+			Cpu:  cpu,
+			Ram:  ram,
+			Disk: disk,
+		},
+	}
+}
+
+type scaleEnv struct {
+	cluster    *clusterv1.Cluster
+	currentPkg *bookingv1.Package
+	newPkg     *bookingv1.Package
+}
+
+func setupScale(env *testutil.TestEnv, s scaleEnv) {
+	env.Server.GetClusterCalls.Returns(&clusterv1.GetClusterResponse{Cluster: s.cluster}, nil)
+	env.BookingServer.GetPackageCalls.Returns(&bookingv1.GetPackageResponse{Package: s.currentPkg}, nil)
+	env.BookingServer.ListPackagesCalls.Returns(&bookingv1.ListPackagesResponse{Items: []*bookingv1.Package{s.newPkg}}, nil)
+	env.Server.UpdateClusterCalls.Always(func(_ context.Context, req *clusterv1.UpdateClusterRequest) (*clusterv1.UpdateClusterResponse, error) {
+		return &clusterv1.UpdateClusterResponse{Cluster: req.GetCluster()}, nil
+	})
+}
+
+func TestScale_NoChanges(t *testing.T) {
+	env := testutil.NewTestEnv(t)
+	pkg := scalePkg(pkgID1, "1000m", "4GiB", "50GiB")
+	setupScale(env, scaleEnv{
+		cluster:    baseCluster(),
+		currentPkg: pkg,
+		newPkg:     pkg,
+	})
+
+	_, _, err := testutil.Exec(t, env, "cluster", "scale", "cluster-123", "--force")
+	require.NoError(t, err)
+
+	req, ok := env.Server.UpdateClusterCalls.Last()
+	require.True(t, ok)
+	assert.Equal(t, pkgID1, req.GetCluster().GetConfiguration().GetPackageId())
+	assert.Equal(t, uint32(0), req.GetCluster().GetConfiguration().GetAdditionalResources().GetDisk())
+	assert.Equal(t, 0, env.BookingServer.ListPackagesCalls.Count())
+}
+
+func TestScale_Nodes(t *testing.T) {
+	env := testutil.NewTestEnv(t)
+	pkg := scalePkg(pkgID1, "1000m", "4GiB", "50GiB")
+	setupScale(env, scaleEnv{
+		cluster:    baseCluster(),
+		currentPkg: pkg,
+		newPkg:     pkg,
+	})
+
+	_, _, err := testutil.Exec(t, env, "cluster", "scale", "cluster-123", "--nodes", "3", "--force")
+	require.NoError(t, err)
+
+	req, ok := env.Server.UpdateClusterCalls.Last()
+	require.True(t, ok)
+	assert.Equal(t, uint32(3), req.GetCluster().GetConfiguration().GetNumberOfNodes())
+	assert.Equal(t, 0, env.BookingServer.ListPackagesCalls.Count())
+}
+
+func TestScale_CPU(t *testing.T) {
+	env := testutil.NewTestEnv(t)
+	setupScale(env, scaleEnv{
+		cluster:    baseCluster(),
+		currentPkg: scalePkg(pkgID1, "1000m", "4GiB", "50GiB"),
+		newPkg:     scalePkg(pkgID2, "2000m", "4GiB", "50GiB"),
+	})
+
+	_, _, err := testutil.Exec(t, env, "cluster", "scale", "cluster-123", "--cpu", "2", "--force")
+	require.NoError(t, err)
+
+	req, ok := env.Server.UpdateClusterCalls.Last()
+	require.True(t, ok)
+	assert.Equal(t, pkgID2, req.GetCluster().GetConfiguration().GetPackageId())
+	assert.Equal(t, 1, env.BookingServer.ListPackagesCalls.Count())
+}
+
+func TestScale_RAM(t *testing.T) {
+	env := testutil.NewTestEnv(t)
+	setupScale(env, scaleEnv{
+		cluster:    baseCluster(),
+		currentPkg: scalePkg(pkgID1, "1000m", "4GiB", "50GiB"),
+		newPkg:     scalePkg(pkgID3, "1000m", "8GiB", "50GiB"),
+	})
+
+	_, _, err := testutil.Exec(t, env, "cluster", "scale", "cluster-123", "--ram", "8GiB", "--force")
+	require.NoError(t, err)
+
+	req, ok := env.Server.UpdateClusterCalls.Last()
+	require.True(t, ok)
+	assert.Equal(t, pkgID3, req.GetCluster().GetConfiguration().GetPackageId())
+}
+
+func TestScale_DiskAbovePackageMinimum(t *testing.T) {
+	env := testutil.NewTestEnv(t)
+	pkg := scalePkg(pkgID1, "1000m", "4GiB", "50GiB")
+	setupScale(env, scaleEnv{
+		cluster:    baseCluster(),
+		currentPkg: pkg,
+		newPkg:     pkg,
+	})
+
+	_, _, err := testutil.Exec(t, env, "cluster", "scale", "cluster-123", "--disk", "150GiB", "--force")
+	require.NoError(t, err)
+
+	req, ok := env.Server.UpdateClusterCalls.Last()
+	require.True(t, ok)
+	// 150GiB total - 50GiB pkg = 100GiB additional
+	assert.Equal(t, uint32(100), req.GetCluster().GetConfiguration().GetAdditionalResources().GetDisk())
+}
+
+func TestScale_DiskBelowPackageMinimumIsOverridden(t *testing.T) {
+	env := testutil.NewTestEnv(t)
+	setupScale(env, scaleEnv{
+		cluster:    baseCluster(),
+		currentPkg: scalePkg(pkgID1, "1000m", "4GiB", "50GiB"),
+		newPkg:     scalePkg(pkgID4, "2000m", "4GiB", "100GiB"),
+	})
+
+	_, _, err := testutil.Exec(t, env, "cluster", "scale", "cluster-123", "--cpu", "2", "--disk", "80GiB", "--force")
+	require.NoError(t, err)
+
+	req, ok := env.Server.UpdateClusterCalls.Last()
+	require.True(t, ok)
+	// effective = max(80GiB requested, 100GiB pkg) = 100GiB; additional = 100 - 100 = 0
+	assert.Equal(t, uint32(0), req.GetCluster().GetConfiguration().GetAdditionalResources().GetDisk())
+}
+
+func TestScale_NewPackageWithLargerDiskUpgradesDiskSilently(t *testing.T) {
+	env := testutil.NewTestEnv(t)
+	setupScale(env, scaleEnv{
+		cluster:    baseCluster(),
+		currentPkg: scalePkg(pkgID1, "1000m", "4GiB", "50GiB"),
+		newPkg:     scalePkg(pkgID4, "2000m", "4GiB", "100GiB"),
+	})
+
+	_, _, err := testutil.Exec(t, env, "cluster", "scale", "cluster-123", "--cpu", "2", "--force")
+	require.NoError(t, err)
+
+	req, ok := env.Server.UpdateClusterCalls.Last()
+	require.True(t, ok)
+	// effective = max(50GiB current, 100GiB new pkg) = 100GiB; additional = 100 - 100 = 0
+	assert.Equal(t, uint32(0), req.GetCluster().GetConfiguration().GetAdditionalResources().GetDisk())
+}
+
+func TestScale_DiskDownscaleIsRejected(t *testing.T) {
+	env := testutil.NewTestEnv(t)
+	pkg := scalePkg(pkgID1, "1000m", "4GiB", "50GiB")
+	cluster := baseCluster()
+	cluster.Configuration.AdditionalResources = &clusterv1.AdditionalResources{Disk: 50} // 50GiB pkg + 50GiB extra = 100GiB total
+	setupScale(env, scaleEnv{
+		cluster:    cluster,
+		currentPkg: pkg,
+		newPkg:     pkg,
+	})
+
+	_, _, err := testutil.Exec(t, env, "cluster", "scale", "cluster-123", "--disk", "80GiB", "--force")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot be downscaled")
+	assert.Equal(t, 0, env.Server.UpdateClusterCalls.Count())
+}
+
+func TestScale_AbortWithoutForce(t *testing.T) {
+	env := testutil.NewTestEnv(t)
+	pkg := scalePkg(pkgID1, "1000m", "4GiB", "50GiB")
+	setupScale(env, scaleEnv{
+		cluster:    baseCluster(),
+		currentPkg: pkg,
+		newPkg:     pkg,
+	})
+
+	stdout, _, err := testutil.Exec(t, env, "cluster", "scale", "cluster-123")
+	require.NoError(t, err)
+	assert.Contains(t, stdout, "Aborted.")
+	assert.Equal(t, 0, env.Server.UpdateClusterCalls.Count())
+}
+
+func TestScale_MissingClusterID(t *testing.T) {
+	env := testutil.NewTestEnv(t)
+
+	_, _, err := testutil.Exec(t, env, "cluster", "scale")
+	require.Error(t, err)
+}
+
+func TestScale_GetClusterError(t *testing.T) {
+	env := testutil.NewTestEnv(t)
+	env.Server.GetClusterCalls.Returns(nil, status.Error(codes.NotFound, "not found"))
+
+	_, _, err := testutil.Exec(t, env, "cluster", "scale", "cluster-123", "--force")
+	require.Error(t, err)
+	assert.Equal(t, 0, env.BookingServer.GetPackageCalls.Count())
+}
+
+func TestScale_GetPackageError(t *testing.T) {
+	env := testutil.NewTestEnv(t)
+	env.Server.GetClusterCalls.Returns(&clusterv1.GetClusterResponse{Cluster: baseCluster()}, nil)
+	env.BookingServer.GetPackageCalls.Returns(nil, status.Error(codes.Internal, "package error"))
+
+	_, _, err := testutil.Exec(t, env, "cluster", "scale", "cluster-123", "--force")
+	require.Error(t, err)
+	assert.Equal(t, 0, env.BookingServer.ListPackagesCalls.Count())
+}
+
+func TestScale_PackageNotFound(t *testing.T) {
+	env := testutil.NewTestEnv(t)
+	currentPkg := scalePkg(pkgID1, "1000m", "4GiB", "50GiB")
+	env.Server.GetClusterCalls.Returns(&clusterv1.GetClusterResponse{Cluster: baseCluster()}, nil)
+	env.BookingServer.GetPackageCalls.Returns(&bookingv1.GetPackageResponse{Package: currentPkg}, nil)
+	env.BookingServer.ListPackagesCalls.Returns(&bookingv1.ListPackagesResponse{Items: nil}, nil)
+
+	_, _, err := testutil.Exec(t, env, "cluster", "scale", "cluster-123", "--cpu", "1", "--force")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no package found")
+}
+
+func TestScale_AmbiguousPackageMatch(t *testing.T) {
+	env := testutil.NewTestEnv(t)
+	currentPkg := scalePkg(pkgID1, "1000m", "4GiB", "50GiB")
+	pkgA := scalePkg(pkgIDA, "1000m", "4GiB", "50GiB")
+	pkgB := scalePkg(pkgIDB, "1000m", "4GiB", "80GiB")
+	env.Server.GetClusterCalls.Returns(&clusterv1.GetClusterResponse{Cluster: baseCluster()}, nil)
+	env.BookingServer.GetPackageCalls.Returns(&bookingv1.GetPackageResponse{Package: currentPkg}, nil)
+	env.BookingServer.ListPackagesCalls.Returns(&bookingv1.ListPackagesResponse{Items: []*bookingv1.Package{pkgA, pkgB}}, nil)
+
+	_, _, err := testutil.Exec(t, env, "cluster", "scale", "cluster-123", "--cpu", "1", "--force")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "multiple packages match")
+}
+
+func TestScale_UpdateClusterError(t *testing.T) {
+	env := testutil.NewTestEnv(t)
+	pkg := scalePkg(pkgID1, "1000m", "4GiB", "50GiB")
+	env.Server.GetClusterCalls.Returns(&clusterv1.GetClusterResponse{Cluster: baseCluster()}, nil)
+	env.BookingServer.GetPackageCalls.Returns(&bookingv1.GetPackageResponse{Package: pkg}, nil)
+	env.BookingServer.ListPackagesCalls.Returns(&bookingv1.ListPackagesResponse{Items: []*bookingv1.Package{pkg}}, nil)
+	env.Server.UpdateClusterCalls.Returns(nil, status.Error(codes.Internal, "update failed"))
+
+	_, _, err := testutil.Exec(t, env, "cluster", "scale", "cluster-123", "--force")
+	require.Error(t, err)
+}
+
+func TestScale_WaitSuccess(t *testing.T) {
+	env := testutil.NewTestEnv(t)
+	pkg := scalePkg(pkgID1, "1000m", "4GiB", "50GiB")
+	cluster := baseCluster()
+
+	env.Server.GetClusterCalls.
+		OnCall(0, func(_ context.Context, _ *clusterv1.GetClusterRequest) (*clusterv1.GetClusterResponse, error) {
+			return &clusterv1.GetClusterResponse{Cluster: cluster}, nil
+		}).
+		OnCall(1, func(_ context.Context, _ *clusterv1.GetClusterRequest) (*clusterv1.GetClusterResponse, error) {
+			return &clusterv1.GetClusterResponse{Cluster: &clusterv1.Cluster{
+				Id:   "cluster-123",
+				Name: "test-cluster",
+				State: &clusterv1.ClusterState{
+					Phase: clusterv1.ClusterPhase_CLUSTER_PHASE_SCALING,
+				},
+			}}, nil
+		}).
+		Always(func(_ context.Context, _ *clusterv1.GetClusterRequest) (*clusterv1.GetClusterResponse, error) {
+			return &clusterv1.GetClusterResponse{Cluster: &clusterv1.Cluster{
+				Id:   "cluster-123",
+				Name: "test-cluster",
+				State: &clusterv1.ClusterState{
+					Phase: clusterv1.ClusterPhase_CLUSTER_PHASE_HEALTHY,
+				},
+			}}, nil
+		})
+	env.BookingServer.GetPackageCalls.Returns(&bookingv1.GetPackageResponse{Package: pkg}, nil)
+	env.BookingServer.ListPackagesCalls.Returns(&bookingv1.ListPackagesResponse{Items: []*bookingv1.Package{pkg}}, nil)
+	env.Server.UpdateClusterCalls.Always(func(_ context.Context, req *clusterv1.UpdateClusterRequest) (*clusterv1.UpdateClusterResponse, error) {
+		return &clusterv1.UpdateClusterResponse{Cluster: req.GetCluster()}, nil
+	})
+
+	stdout, stderr, err := testutil.Exec(t, env,
+		"cluster", "scale", "cluster-123", "--force",
+		"--wait",
+		"--wait-timeout", "30s",
+		"--wait-poll-interval", "10ms",
+	)
+	require.NoError(t, err)
+	assert.Contains(t, stderr, "Scaling Cluster")
+	assert.Contains(t, stdout, "scaled successfully")
+}
+
+func TestScale_WaitTimeout(t *testing.T) {
+	env := testutil.NewTestEnv(t)
+	pkg := scalePkg(pkgID1, "1000m", "4GiB", "50GiB")
+	cluster := baseCluster()
+
+	env.Server.GetClusterCalls.
+		OnCall(0, func(_ context.Context, _ *clusterv1.GetClusterRequest) (*clusterv1.GetClusterResponse, error) {
+			return &clusterv1.GetClusterResponse{Cluster: cluster}, nil
+		}).
+		Always(func(_ context.Context, _ *clusterv1.GetClusterRequest) (*clusterv1.GetClusterResponse, error) {
+			return &clusterv1.GetClusterResponse{Cluster: &clusterv1.Cluster{
+				Id: "cluster-123",
+				State: &clusterv1.ClusterState{
+					Phase: clusterv1.ClusterPhase_CLUSTER_PHASE_SCALING,
+				},
+			}}, nil
+		})
+	env.BookingServer.GetPackageCalls.Returns(&bookingv1.GetPackageResponse{Package: pkg}, nil)
+	env.BookingServer.ListPackagesCalls.Returns(&bookingv1.ListPackagesResponse{Items: []*bookingv1.Package{pkg}}, nil)
+	env.Server.UpdateClusterCalls.Always(func(_ context.Context, req *clusterv1.UpdateClusterRequest) (*clusterv1.UpdateClusterResponse, error) {
+		return &clusterv1.UpdateClusterResponse{Cluster: req.GetCluster()}, nil
+	})
+
+	_, _, err := testutil.Exec(t, env,
+		"cluster", "scale", "cluster-123", "--force",
+		"--wait",
+		"--wait-timeout", "50ms",
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "timed out")
+}
+
+func TestScale_NoWait(t *testing.T) {
+	env := testutil.NewTestEnv(t)
+	pkg := scalePkg(pkgID1, "1000m", "4GiB", "50GiB")
+	env.Server.GetClusterCalls.Returns(&clusterv1.GetClusterResponse{Cluster: baseCluster()}, nil)
+	env.BookingServer.GetPackageCalls.Returns(&bookingv1.GetPackageResponse{Package: pkg}, nil)
+	env.BookingServer.ListPackagesCalls.Returns(&bookingv1.ListPackagesResponse{Items: []*bookingv1.Package{pkg}}, nil)
+	env.Server.UpdateClusterCalls.Always(func(_ context.Context, req *clusterv1.UpdateClusterRequest) (*clusterv1.UpdateClusterResponse, error) {
+		c := req.GetCluster()
+		c.State = &clusterv1.ClusterState{Phase: clusterv1.ClusterPhase_CLUSTER_PHASE_SCALING}
+		return &clusterv1.UpdateClusterResponse{Cluster: c}, nil
+	})
+
+	stdout, _, err := testutil.Exec(t, env, "cluster", "scale", "cluster-123", "--force")
+	require.NoError(t, err)
+	assert.Contains(t, stdout, "it will take some time")
+	assert.Equal(t, 1, env.Server.GetClusterCalls.Count(), "GetCluster should be called only once without --wait")
+}
+
+func TestScale_PrintsSuccessWhenClusterIsHealthy(t *testing.T) {
+	env := testutil.NewTestEnv(t)
+	pkg := scalePkg(pkgID1, "1000m", "4GiB", "50GiB")
+	env.Server.GetClusterCalls.Returns(&clusterv1.GetClusterResponse{Cluster: baseCluster()}, nil)
+	env.BookingServer.GetPackageCalls.Returns(&bookingv1.GetPackageResponse{Package: pkg}, nil)
+	env.BookingServer.ListPackagesCalls.Returns(&bookingv1.ListPackagesResponse{Items: []*bookingv1.Package{pkg}}, nil)
+	env.Server.UpdateClusterCalls.Always(func(_ context.Context, req *clusterv1.UpdateClusterRequest) (*clusterv1.UpdateClusterResponse, error) {
+		c := req.GetCluster()
+		c.State = &clusterv1.ClusterState{Phase: clusterv1.ClusterPhase_CLUSTER_PHASE_HEALTHY}
+		return &clusterv1.UpdateClusterResponse{Cluster: c}, nil
+	})
+
+	stdout, _, err := testutil.Exec(t, env, "cluster", "scale", "cluster-123", "--force")
+	require.NoError(t, err)
+	assert.Contains(t, stdout, "scaled successfully")
+}
+
+func TestScale_PrintsScalingWhenClusterIsNotYetHealthy(t *testing.T) {
+	env := testutil.NewTestEnv(t)
+	pkg := scalePkg(pkgID1, "1000m", "4GiB", "50GiB")
+	env.Server.GetClusterCalls.Returns(&clusterv1.GetClusterResponse{Cluster: baseCluster()}, nil)
+	env.BookingServer.GetPackageCalls.Returns(&bookingv1.GetPackageResponse{Package: pkg}, nil)
+	env.BookingServer.ListPackagesCalls.Returns(&bookingv1.ListPackagesResponse{Items: []*bookingv1.Package{pkg}}, nil)
+	env.Server.UpdateClusterCalls.Always(func(_ context.Context, req *clusterv1.UpdateClusterRequest) (*clusterv1.UpdateClusterResponse, error) {
+		c := req.GetCluster()
+		c.State = &clusterv1.ClusterState{Phase: clusterv1.ClusterPhase_CLUSTER_PHASE_SCALING}
+		return &clusterv1.UpdateClusterResponse{Cluster: c}, nil
+	})
+
+	stdout, _, err := testutil.Exec(t, env, "cluster", "scale", "cluster-123", "--force")
+	require.NoError(t, err)
+	assert.Contains(t, stdout, "is scaling")
+	assert.Contains(t, stdout, "cluster-123")
+}
+
+func TestScale_NoResourceFlagsSkipsPackageResolution(t *testing.T) {
+	env := testutil.NewTestEnv(t)
+	pkg := scalePkg(pkgID1, "1000m", "4GiB", "50GiB")
+	setupScale(env, scaleEnv{
+		cluster:    baseCluster(),
+		currentPkg: pkg,
+		newPkg:     pkg,
+	})
+
+	_, _, err := testutil.Exec(t, env, "cluster", "scale", "cluster-123", "--force")
+	require.NoError(t, err)
+
+	assert.Equal(t, 0, env.BookingServer.ListPackagesCalls.Count())
+	req, ok := env.Server.UpdateClusterCalls.Last()
+	require.True(t, ok)
+	assert.Equal(t, pkgID1, req.GetCluster().GetConfiguration().GetPackageId())
+}
+
+func TestScale_DeprecatedCurrentPackageSucceedsWithNoResourceFlags(t *testing.T) {
+	env := testutil.NewTestEnv(t)
+	currentPkg := scalePkg(pkgID1, "1000m", "4GiB", "50GiB")
+	env.Server.GetClusterCalls.Returns(&clusterv1.GetClusterResponse{Cluster: baseCluster()}, nil)
+	env.BookingServer.GetPackageCalls.Returns(&bookingv1.GetPackageResponse{Package: currentPkg}, nil)
+	// ListPackages returns empty — simulates a deprecated package absent from the active list.
+	env.BookingServer.ListPackagesCalls.Returns(&bookingv1.ListPackagesResponse{Items: nil}, nil)
+	env.Server.UpdateClusterCalls.Always(func(_ context.Context, req *clusterv1.UpdateClusterRequest) (*clusterv1.UpdateClusterResponse, error) {
+		return &clusterv1.UpdateClusterResponse{Cluster: req.GetCluster()}, nil
+	})
+
+	_, _, err := testutil.Exec(t, env, "cluster", "scale", "cluster-123", "--force")
+	require.NoError(t, err)
+
+	assert.Equal(t, 0, env.BookingServer.ListPackagesCalls.Count())
+	req, ok := env.Server.UpdateClusterCalls.Last()
+	require.True(t, ok)
+	assert.Equal(t, pkgID1, req.GetCluster().GetConfiguration().GetPackageId())
+}

--- a/internal/cmd/cluster/update.go
+++ b/internal/cmd/cluster/update.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/qdrant/qcloud-cli/internal/cmd/base"
 	"github.com/qdrant/qcloud-cli/internal/cmd/completion"
+	"github.com/qdrant/qcloud-cli/internal/cmd/util"
 	"github.com/qdrant/qcloud-cli/internal/state"
 )
 
@@ -20,7 +21,7 @@ func newUpdateCommand(s *state.State) *cobra.Command {
 			cmd := &cobra.Command{
 				Use:   "update <cluster-id>",
 				Short: "Update an existing cluster",
-				Args:  cobra.ExactArgs(1),
+				Args:  util.ExactArgs(1, "a cluster ID"),
 			}
 			cmd.Flags().StringToString("label", nil, "Label to apply to the cluster ('key=value'), can be specified multiple times; replaces all existing labels")
 			return cmd

--- a/internal/resource/bytes.go
+++ b/internal/resource/bytes.go
@@ -58,14 +58,16 @@ func ParseByteQuantity(s string) (ByteQuantity, error) {
 		{"K", KiB},
 	}
 	for _, e := range suffixes {
-		if strings.HasSuffix(s, e.suffix) {
-			n, err := strconv.ParseInt(strings.TrimSuffix(s, e.suffix), 10, 64)
+		if q, ok := strings.CutSuffix(s, e.suffix); ok {
+			n, err := strconv.ParseInt(q, 10, 64)
 			if err != nil {
 				return 0, fmt.Errorf("cannot parse %q as a byte quantity", s)
 			}
+
 			return ByteQuantity(n) * e.mult, nil
 		}
 	}
+
 	// Bare integer: treat as GiB.
 	n, err := strconv.ParseInt(s, 10, 64)
 	if err != nil {


### PR DESCRIPTION
## Add `cluster scale` command

Adds a new `qcloud cluster scale` command that lets users resize a cluster's compute resources and node count in place.

- Accepts `--cpu`, `--ram`, `--gpu`, `--disk`, and `--nodes` flags to adjust any combination of resources in a single operation
- Resolves the appropriate package from the available catalog when resource flags change; skips the catalog lookup entirely when only node count or disk is adjusted
- Computes additional disk storage as the delta between requested total disk and the package's included disk, and rejects disk downscales
- Shows a confirmation prompt with a before/after diff of all changing fields; accepts `--force` to skip it
- Optionally waits for the cluster to return to a healthy state with `--wait`, `--wait-timeout`, and `--wait-poll-interval`
- Supports shell completion for all resource flags

Also fixes `cluster update` to use `util.ExactArgs` for consistent error messages, and cleans up `bytes.go` to use `strings.CutSuffix`.