### PR TITLE
feat: add remaining database configuration cluster update

### DIFF
--- a/internal/cmd/cluster/completion.go
+++ b/internal/cmd/cluster/completion.go
@@ -294,6 +294,20 @@ func diskPerformanceCompletion() func(*cobra.Command, []string, string) ([]strin
 	}
 }
 
+// restartModeCompletion returns a static completion function for the --restart-mode flag.
+func restartModeCompletion() func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
+	return func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+		return []string{restartModeRolling, restartModeParallel, restartModeAutomatic}, cobra.ShellCompDirectiveNoFileComp
+	}
+}
+
+// rebalanceStrategyCompletion returns a static completion function for the --rebalance-strategy flag.
+func rebalanceStrategyCompletion() func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
+	return func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+		return []string{rebalanceByCount, rebalanceBySize, rebalanceByCountAndSize}, cobra.ShellCompDirectiveNoFileComp
+	}
+}
+
 // packageCompletion returns a completion function for the --package flag.
 func packageCompletion(s *state.State) func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
 	return func(cmd *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {

--- a/internal/cmd/cluster/create.go
+++ b/internal/cmd/cluster/create.go
@@ -40,8 +40,15 @@ func newCreateCommand(s *state.State) *cobra.Command {
 			cmd.Flags().Bool("wait", false, "Wait for the cluster to become healthy")
 			cmd.Flags().Duration("wait-timeout", 10*time.Minute, "Maximum time to wait for cluster health")
 			cmd.Flags().Duration("wait-poll-interval", 5*time.Second, "How often to poll for cluster health")
-			_ = cmd.Flags().MarkHidden("wait-poll-interval")
 			cmd.Flags().String("disk-performance", "", `Disk performance tier ("balanced", "cost-optimised", "performance")`)
+			cmd.Flags().Uint32("replication-factor", 0, "Default replication factor for new collections")
+			cmd.Flags().Int32("write-consistency-factor", 0, "Default write consistency factor for new collections")
+			cmd.Flags().Bool("async-scorer", false, "Enable async scorer (uses io_uring on Linux)")
+			cmd.Flags().Int32("optimizer-cpu-budget", 0, `CPU threads for optimization (0=auto, negative=subtract from available CPUs, positive=exact count)`)
+			cmd.Flags().StringSlice("allowed-ips", nil, "Allowed client IP CIDR ranges; max 20")
+			cmd.Flags().String("restart-mode", "", `Restart policy ("rolling", "parallel", "automatic")`)
+			cmd.Flags().String("rebalance-strategy", "", `Shard rebalance strategy ("by-count", "by-size", "by-count-and-size")`)
+			_ = cmd.Flags().MarkHidden("wait-poll-interval")
 			_ = cmd.MarkFlagRequired("cloud-provider")
 			_ = cmd.MarkFlagRequired("cloud-region")
 			return cmd
@@ -153,6 +160,70 @@ func newCreateCommand(s *state.State) *cobra.Command {
 				}
 			}
 
+			// Database configuration flags
+			if cmd.Flags().Changed("replication-factor") || cmd.Flags().Changed("write-consistency-factor") ||
+				cmd.Flags().Changed("async-scorer") || cmd.Flags().Changed("optimizer-cpu-budget") {
+				if cluster.Configuration.DatabaseConfiguration == nil {
+					cluster.Configuration.DatabaseConfiguration = &clusterv1.DatabaseConfiguration{}
+				}
+				dbCfg := cluster.Configuration.DatabaseConfiguration
+
+				if cmd.Flags().Changed("replication-factor") || cmd.Flags().Changed("write-consistency-factor") {
+					if dbCfg.Collection == nil {
+						dbCfg.Collection = &clusterv1.DatabaseConfigurationCollection{}
+					}
+					if cmd.Flags().Changed("replication-factor") {
+						v, _ := cmd.Flags().GetUint32("replication-factor")
+						dbCfg.Collection.ReplicationFactor = &v
+					}
+					if cmd.Flags().Changed("write-consistency-factor") {
+						v, _ := cmd.Flags().GetInt32("write-consistency-factor")
+						dbCfg.Collection.WriteConsistencyFactor = &v
+					}
+				}
+
+				if cmd.Flags().Changed("async-scorer") || cmd.Flags().Changed("optimizer-cpu-budget") {
+					if dbCfg.Storage == nil {
+						dbCfg.Storage = &clusterv1.DatabaseConfigurationStorage{}
+					}
+					if dbCfg.Storage.Performance == nil {
+						dbCfg.Storage.Performance = &clusterv1.DatabaseConfigurationStoragePerformance{}
+					}
+					if cmd.Flags().Changed("async-scorer") {
+						v, _ := cmd.Flags().GetBool("async-scorer")
+						dbCfg.Storage.Performance.AsyncScorer = &v
+					}
+					if cmd.Flags().Changed("optimizer-cpu-budget") {
+						v, _ := cmd.Flags().GetInt32("optimizer-cpu-budget")
+						dbCfg.Storage.Performance.OptimizerCpuBudget = &v
+					}
+				}
+			}
+
+			// Cluster configuration flags
+			if cmd.Flags().Changed("allowed-ips") {
+				ips, _ := cmd.Flags().GetStringSlice("allowed-ips")
+				cluster.Configuration.AllowedIpSourceRanges = ips
+			}
+
+			if cmd.Flags().Changed("restart-mode") {
+				modeStr, _ := cmd.Flags().GetString("restart-mode")
+				mode, err := parseRestartMode(modeStr)
+				if err != nil {
+					return nil, err
+				}
+				cluster.Configuration.RestartPolicy = mode.Enum()
+			}
+
+			if cmd.Flags().Changed("rebalance-strategy") {
+				stratStr, _ := cmd.Flags().GetString("rebalance-strategy")
+				strat, err := parseRebalanceStrategy(stratStr)
+				if err != nil {
+					return nil, err
+				}
+				cluster.Configuration.RebalanceStrategy = strat.Enum()
+			}
+
 			if cmd.Flags().Changed("disk") && pkg != nil {
 				requestedDisk := *cmd.Flags().Lookup("disk").Value.(*resource.ByteQuantity)
 				if pkgDiskStr := pkg.GetResourceConfiguration().GetDisk(); pkgDiskStr != "" {
@@ -206,5 +277,7 @@ func newCreateCommand(s *state.State) *cobra.Command {
 	_ = cmd.RegisterFlagCompletionFunc("disk", diskCompletion(s))
 	_ = cmd.RegisterFlagCompletionFunc("gpu", gpuCompletion(s))
 	_ = cmd.RegisterFlagCompletionFunc("disk-performance", diskPerformanceCompletion())
+	_ = cmd.RegisterFlagCompletionFunc("restart-mode", restartModeCompletion())
+	_ = cmd.RegisterFlagCompletionFunc("rebalance-strategy", rebalanceStrategyCompletion())
 	return cmd
 }

--- a/internal/cmd/cluster/create_test.go
+++ b/internal/cmd/cluster/create_test.go
@@ -675,3 +675,223 @@ func TestCreateCluster_ExplicitNameSkipsSuggest(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 0, env.Server.SuggestClusterNameCalls.Count(), "SuggestClusterName should not be called when --name is provided")
 }
+
+func TestCreateCluster_WithReplicationFactor(t *testing.T) {
+	env := testutil.NewTestEnv(t)
+
+	env.Server.CreateClusterCalls.Returns(&clusterv1.CreateClusterResponse{
+		Cluster: &clusterv1.Cluster{Id: "cluster-rf"},
+	}, nil)
+
+	_, _, err := testutil.Exec(t, env,
+		"cluster", "create",
+		"--name", "my-cluster",
+		"--cloud-provider", "aws",
+		"--cloud-region", "us-east-1",
+		"--package", "00000000-0000-0000-0000-000000000001",
+		"--replication-factor", "3",
+	)
+	require.NoError(t, err)
+
+	req, ok := env.Server.CreateClusterCalls.Last()
+	require.True(t, ok)
+	rf := req.GetCluster().GetConfiguration().GetDatabaseConfiguration().GetCollection().GetReplicationFactor()
+	assert.Equal(t, uint32(3), rf)
+}
+
+func TestCreateCluster_WithWriteConsistencyFactor(t *testing.T) {
+	env := testutil.NewTestEnv(t)
+
+	env.Server.CreateClusterCalls.Returns(&clusterv1.CreateClusterResponse{
+		Cluster: &clusterv1.Cluster{Id: "cluster-wcf"},
+	}, nil)
+
+	_, _, err := testutil.Exec(t, env,
+		"cluster", "create",
+		"--name", "my-cluster",
+		"--cloud-provider", "aws",
+		"--cloud-region", "us-east-1",
+		"--package", "00000000-0000-0000-0000-000000000001",
+		"--write-consistency-factor", "2",
+	)
+	require.NoError(t, err)
+
+	req, ok := env.Server.CreateClusterCalls.Last()
+	require.True(t, ok)
+	wcf := req.GetCluster().GetConfiguration().GetDatabaseConfiguration().GetCollection().GetWriteConsistencyFactor()
+	assert.Equal(t, int32(2), wcf)
+}
+
+func TestCreateCluster_WithAsyncScorer(t *testing.T) {
+	env := testutil.NewTestEnv(t)
+
+	env.Server.CreateClusterCalls.Returns(&clusterv1.CreateClusterResponse{
+		Cluster: &clusterv1.Cluster{Id: "cluster-as"},
+	}, nil)
+
+	_, _, err := testutil.Exec(t, env,
+		"cluster", "create",
+		"--name", "my-cluster",
+		"--cloud-provider", "aws",
+		"--cloud-region", "us-east-1",
+		"--package", "00000000-0000-0000-0000-000000000001",
+		"--async-scorer",
+	)
+	require.NoError(t, err)
+
+	req, ok := env.Server.CreateClusterCalls.Last()
+	require.True(t, ok)
+	as := req.GetCluster().GetConfiguration().GetDatabaseConfiguration().GetStorage().GetPerformance().GetAsyncScorer()
+	assert.True(t, as)
+}
+
+func TestCreateCluster_WithOptimizerCPUBudget(t *testing.T) {
+	env := testutil.NewTestEnv(t)
+
+	env.Server.CreateClusterCalls.Returns(&clusterv1.CreateClusterResponse{
+		Cluster: &clusterv1.Cluster{Id: "cluster-ocb"},
+	}, nil)
+
+	_, _, err := testutil.Exec(t, env,
+		"cluster", "create",
+		"--name", "my-cluster",
+		"--cloud-provider", "aws",
+		"--cloud-region", "us-east-1",
+		"--package", "00000000-0000-0000-0000-000000000001",
+		"--optimizer-cpu-budget", "4",
+	)
+	require.NoError(t, err)
+
+	req, ok := env.Server.CreateClusterCalls.Last()
+	require.True(t, ok)
+	budget := req.GetCluster().GetConfiguration().GetDatabaseConfiguration().GetStorage().GetPerformance().GetOptimizerCpuBudget()
+	assert.Equal(t, int32(4), budget)
+}
+
+func TestCreateCluster_WithAllDBConfigFlags(t *testing.T) {
+	env := testutil.NewTestEnv(t)
+
+	env.Server.CreateClusterCalls.Returns(&clusterv1.CreateClusterResponse{
+		Cluster: &clusterv1.Cluster{Id: "cluster-alldb"},
+	}, nil)
+
+	_, _, err := testutil.Exec(t, env,
+		"cluster", "create",
+		"--name", "my-cluster",
+		"--cloud-provider", "aws",
+		"--cloud-region", "us-east-1",
+		"--package", "00000000-0000-0000-0000-000000000001",
+		"--replication-factor", "3",
+		"--write-consistency-factor", "2",
+		"--async-scorer",
+		"--optimizer-cpu-budget", "-1",
+	)
+	require.NoError(t, err)
+
+	req, ok := env.Server.CreateClusterCalls.Last()
+	require.True(t, ok)
+	dbCfg := req.GetCluster().GetConfiguration().GetDatabaseConfiguration()
+	assert.Equal(t, uint32(3), dbCfg.GetCollection().GetReplicationFactor())
+	assert.Equal(t, int32(2), dbCfg.GetCollection().GetWriteConsistencyFactor())
+	assert.True(t, dbCfg.GetStorage().GetPerformance().GetAsyncScorer())
+	assert.Equal(t, int32(-1), dbCfg.GetStorage().GetPerformance().GetOptimizerCpuBudget())
+}
+
+func TestCreateCluster_WithAllowedIPs(t *testing.T) {
+	env := testutil.NewTestEnv(t)
+
+	env.Server.CreateClusterCalls.Returns(&clusterv1.CreateClusterResponse{
+		Cluster: &clusterv1.Cluster{Id: "cluster-ips"},
+	}, nil)
+
+	_, _, err := testutil.Exec(t, env,
+		"cluster", "create",
+		"--name", "my-cluster",
+		"--cloud-provider", "aws",
+		"--cloud-region", "us-east-1",
+		"--package", "00000000-0000-0000-0000-000000000001",
+		"--allowed-ips", "10.0.0.0/8,172.16.0.0/12",
+	)
+	require.NoError(t, err)
+
+	req, ok := env.Server.CreateClusterCalls.Last()
+	require.True(t, ok)
+	ips := req.GetCluster().GetConfiguration().GetAllowedIpSourceRanges()
+	assert.Equal(t, []string{"10.0.0.0/8", "172.16.0.0/12"}, ips)
+}
+
+func TestCreateCluster_WithRestartMode(t *testing.T) {
+	env := testutil.NewTestEnv(t)
+
+	env.Server.CreateClusterCalls.Returns(&clusterv1.CreateClusterResponse{
+		Cluster: &clusterv1.Cluster{Id: "cluster-rm"},
+	}, nil)
+
+	_, _, err := testutil.Exec(t, env,
+		"cluster", "create",
+		"--name", "my-cluster",
+		"--cloud-provider", "aws",
+		"--cloud-region", "us-east-1",
+		"--package", "00000000-0000-0000-0000-000000000001",
+		"--restart-mode", "parallel",
+	)
+	require.NoError(t, err)
+
+	req, ok := env.Server.CreateClusterCalls.Last()
+	require.True(t, ok)
+	rp := req.GetCluster().GetConfiguration().GetRestartPolicy()
+	assert.Equal(t, clusterv1.ClusterConfigurationRestartPolicy_CLUSTER_CONFIGURATION_RESTART_POLICY_PARALLEL, rp)
+}
+
+func TestCreateCluster_WithRebalanceStrategy(t *testing.T) {
+	env := testutil.NewTestEnv(t)
+
+	env.Server.CreateClusterCalls.Returns(&clusterv1.CreateClusterResponse{
+		Cluster: &clusterv1.Cluster{Id: "cluster-rs"},
+	}, nil)
+
+	_, _, err := testutil.Exec(t, env,
+		"cluster", "create",
+		"--name", "my-cluster",
+		"--cloud-provider", "aws",
+		"--cloud-region", "us-east-1",
+		"--package", "00000000-0000-0000-0000-000000000001",
+		"--rebalance-strategy", "by-count-and-size",
+	)
+	require.NoError(t, err)
+
+	req, ok := env.Server.CreateClusterCalls.Last()
+	require.True(t, ok)
+	rs := req.GetCluster().GetConfiguration().GetRebalanceStrategy()
+	assert.Equal(t, clusterv1.ClusterConfigurationRebalanceStrategy_CLUSTER_CONFIGURATION_REBALANCE_STRATEGY_BY_COUNT_AND_SIZE, rs)
+}
+
+func TestCreateCluster_InvalidRestartMode(t *testing.T) {
+	env := testutil.NewTestEnv(t)
+
+	_, _, err := testutil.Exec(t, env,
+		"cluster", "create",
+		"--name", "my-cluster",
+		"--cloud-provider", "aws",
+		"--cloud-region", "us-east-1",
+		"--package", "00000000-0000-0000-0000-000000000001",
+		"--restart-mode", "invalid",
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid restart mode")
+}
+
+func TestCreateCluster_InvalidRebalanceStrategy(t *testing.T) {
+	env := testutil.NewTestEnv(t)
+
+	_, _, err := testutil.Exec(t, env,
+		"cluster", "create",
+		"--name", "my-cluster",
+		"--cloud-provider", "aws",
+		"--cloud-region", "us-east-1",
+		"--package", "00000000-0000-0000-0000-000000000001",
+		"--rebalance-strategy", "invalid",
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid rebalance strategy")
+}

--- a/internal/cmd/cluster/describe.go
+++ b/internal/cmd/cluster/describe.go
@@ -3,6 +3,7 @@ package cluster
 import (
 	"fmt"
 	"io"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -67,6 +68,59 @@ func newDescribeCommand(s *state.State) *cobra.Command {
 						fmt.Fprintf(w, "          ")
 					}
 					fmt.Fprintf(w, "%s=%s\n", kv.GetKey(), kv.GetValue())
+				}
+			}
+
+			if cfg := cluster.GetConfiguration(); cfg != nil {
+				notSet := "(not set)"
+
+				if dbCfg := cfg.GetDatabaseConfiguration(); dbCfg != nil {
+					fmt.Fprintln(w)
+					fmt.Fprintln(w, "Database Configuration:")
+
+					col := dbCfg.GetCollection()
+					fmt.Fprintln(w, "  Collection Defaults:")
+					if col != nil {
+						fmt.Fprintf(w, "    Replication Factor:        %s\n", output.OptionalValue(col.ReplicationFactor, notSet))
+						fmt.Fprintf(w, "    Write Consistency Factor:  %s\n", output.OptionalValue(col.WriteConsistencyFactor, notSet))
+						if vec := col.GetVectors(); vec != nil {
+							fmt.Fprintf(w, "    On Disk:                   %s\n", output.OptionalValue(vec.OnDisk, notSet))
+						} else {
+							fmt.Fprintf(w, "    On Disk:                   %s\n", notSet)
+						}
+					} else {
+						fmt.Fprintf(w, "    Replication Factor:        %s\n", notSet)
+						fmt.Fprintf(w, "    Write Consistency Factor:  %s\n", notSet)
+						fmt.Fprintf(w, "    On Disk:                   %s\n", notSet)
+					}
+
+					perf := dbCfg.GetStorage().GetPerformance()
+					fmt.Fprintln(w, "  Advanced Optimizations:")
+					if perf != nil {
+						fmt.Fprintf(w, "    Optimizer CPU Budget:      %s\n", output.OptionalValue(perf.OptimizerCpuBudget, notSet))
+						fmt.Fprintf(w, "    Async Scorer:              %s\n", output.OptionalValue(perf.AsyncScorer, notSet))
+					} else {
+						fmt.Fprintf(w, "    Optimizer CPU Budget:      %s\n", notSet)
+						fmt.Fprintf(w, "    Async Scorer:              %s\n", notSet)
+					}
+				}
+
+				ips := cfg.GetAllowedIpSourceRanges()
+				restartMode := restartPolicyString(cfg.GetRestartPolicy())
+				rebalance := rebalanceStrategyString(cfg.GetRebalanceStrategy())
+
+				if len(ips) > 0 || restartMode != "" || rebalance != "" {
+					fmt.Fprintln(w)
+					fmt.Fprintln(w, "Cluster Configuration:")
+					if len(ips) > 0 {
+						fmt.Fprintf(w, "  Allowed IPs:          %s\n", strings.Join(ips, ", "))
+					}
+					if restartMode != "" {
+						fmt.Fprintf(w, "  Restart Mode:         %s\n", restartMode)
+					}
+					if rebalance != "" {
+						fmt.Fprintf(w, "  Rebalance Strategy:   %s\n", rebalance)
+					}
 				}
 			}
 

--- a/internal/cmd/cluster/describe_test.go
+++ b/internal/cmd/cluster/describe_test.go
@@ -1,0 +1,349 @@
+package cluster_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	clusterv1 "github.com/qdrant/qdrant-cloud-public-api/gen/go/qdrant/cloud/cluster/v1"
+	commonv1 "github.com/qdrant/qdrant-cloud-public-api/gen/go/qdrant/cloud/common/v1"
+
+	"github.com/qdrant/qcloud-cli/internal/testutil"
+)
+
+func TestDescribeCluster_BasicInfo(t *testing.T) {
+	env := testutil.NewTestEnv(t)
+
+	env.Server.GetClusterCalls.Returns(&clusterv1.GetClusterResponse{
+		Cluster: &clusterv1.Cluster{
+			Id:                    "cluster-abc",
+			Name:                  "my-cluster",
+			CloudProviderId:       "aws",
+			CloudProviderRegionId: "us-east-1",
+			State: &clusterv1.ClusterState{
+				Phase: clusterv1.ClusterPhase_CLUSTER_PHASE_HEALTHY,
+			},
+			Configuration: &clusterv1.ClusterConfiguration{
+				Version:       new("1.13.0"),
+				NumberOfNodes: 3,
+				PackageId:     "pkg-001",
+			},
+			CreatedAt: timestamppb.New(time.Now().Add(-24 * time.Hour)),
+		},
+	}, nil)
+
+	stdout, _, err := testutil.Exec(t, env, "cluster", "describe", "cluster-abc")
+	require.NoError(t, err)
+
+	assert.Contains(t, stdout, "cluster-abc")
+	assert.Contains(t, stdout, "my-cluster")
+	assert.Contains(t, stdout, "HEALTHY")
+	assert.Contains(t, stdout, "1.13.0")
+	assert.Contains(t, stdout, "3")
+	assert.Contains(t, stdout, "pkg-001")
+	assert.Contains(t, stdout, "aws")
+	assert.Contains(t, stdout, "us-east-1")
+	assert.Contains(t, stdout, "ago")
+}
+
+func TestDescribeCluster_MinimalCluster(t *testing.T) {
+	env := testutil.NewTestEnv(t)
+
+	env.Server.GetClusterCalls.Returns(&clusterv1.GetClusterResponse{
+		Cluster: &clusterv1.Cluster{
+			Id:   "minimal-id",
+			Name: "minimal-name",
+		},
+	}, nil)
+
+	stdout, _, err := testutil.Exec(t, env, "cluster", "describe", "minimal-id")
+	require.NoError(t, err)
+
+	assert.Contains(t, stdout, "minimal-id")
+	assert.Contains(t, stdout, "minimal-name")
+	assert.NotContains(t, stdout, "Status:")
+	assert.NotContains(t, stdout, "Version:")
+}
+
+func TestDescribeCluster_Labels(t *testing.T) {
+	env := testutil.NewTestEnv(t)
+
+	env.Server.GetClusterCalls.Returns(&clusterv1.GetClusterResponse{
+		Cluster: &clusterv1.Cluster{
+			Id:   "labeled-cluster",
+			Name: "labeled",
+			Labels: []*commonv1.KeyValue{
+				{Key: "env", Value: "production"},
+				{Key: "team", Value: "platform"},
+			},
+		},
+	}, nil)
+
+	stdout, _, err := testutil.Exec(t, env, "cluster", "describe", "labeled-cluster")
+	require.NoError(t, err)
+
+	assert.Contains(t, stdout, "env=production")
+	assert.Contains(t, stdout, "team=platform")
+}
+
+func TestDescribeCluster_DatabaseConfiguration(t *testing.T) {
+	env := testutil.NewTestEnv(t)
+
+	env.Server.GetClusterCalls.Returns(&clusterv1.GetClusterResponse{
+		Cluster: &clusterv1.Cluster{
+			Id:   "dbcfg-cluster",
+			Name: "dbcfg",
+			Configuration: &clusterv1.ClusterConfiguration{
+				DatabaseConfiguration: &clusterv1.DatabaseConfiguration{
+					Collection: &clusterv1.DatabaseConfigurationCollection{
+						ReplicationFactor:      new(uint32(3)),
+						WriteConsistencyFactor: new(int32(2)),
+						Vectors: &clusterv1.DatabaseConfigurationCollectionVectors{
+							OnDisk: new(true),
+						},
+					},
+					Storage: &clusterv1.DatabaseConfigurationStorage{
+						Performance: &clusterv1.DatabaseConfigurationStoragePerformance{
+							OptimizerCpuBudget: new(int32(4)),
+							AsyncScorer:        new(true),
+						},
+					},
+				},
+			},
+		},
+	}, nil)
+
+	stdout, _, err := testutil.Exec(t, env, "cluster", "describe", "dbcfg-cluster")
+	require.NoError(t, err)
+
+	assert.Contains(t, stdout, "Database Configuration:")
+	assert.Contains(t, stdout, "Collection Defaults:")
+	assert.Contains(t, stdout, "Replication Factor:")
+	assert.Contains(t, stdout, "3")
+	assert.Contains(t, stdout, "Write Consistency Factor:")
+	assert.Contains(t, stdout, "2")
+	assert.Contains(t, stdout, "On Disk:")
+	assert.Contains(t, stdout, "yes")
+	assert.Contains(t, stdout, "Advanced Optimizations:")
+	assert.Contains(t, stdout, "Optimizer CPU Budget:")
+	assert.Contains(t, stdout, "4")
+	assert.Contains(t, stdout, "Async Scorer:")
+}
+
+func TestDescribeCluster_DatabaseConfiguration_NotSet(t *testing.T) {
+	env := testutil.NewTestEnv(t)
+
+	env.Server.GetClusterCalls.Returns(&clusterv1.GetClusterResponse{
+		Cluster: &clusterv1.Cluster{
+			Id:   "dbcfg-notset",
+			Name: "dbcfg-notset",
+			Configuration: &clusterv1.ClusterConfiguration{
+				DatabaseConfiguration: &clusterv1.DatabaseConfiguration{},
+			},
+		},
+	}, nil)
+
+	stdout, _, err := testutil.Exec(t, env, "cluster", "describe", "dbcfg-notset")
+	require.NoError(t, err)
+
+	assert.Contains(t, stdout, "Database Configuration:")
+	assert.Contains(t, stdout, "(not set)")
+}
+
+func TestDescribeCluster_ClusterConfiguration(t *testing.T) {
+	env := testutil.NewTestEnv(t)
+
+	rollingPolicy := clusterv1.ClusterConfigurationRestartPolicy_CLUSTER_CONFIGURATION_RESTART_POLICY_ROLLING
+	byCountStrategy := clusterv1.ClusterConfigurationRebalanceStrategy_CLUSTER_CONFIGURATION_REBALANCE_STRATEGY_BY_COUNT
+
+	env.Server.GetClusterCalls.Returns(&clusterv1.GetClusterResponse{
+		Cluster: &clusterv1.Cluster{
+			Id:   "clustercfg-id",
+			Name: "clustercfg",
+			Configuration: &clusterv1.ClusterConfiguration{
+				AllowedIpSourceRanges: []string{"10.0.0.0/8", "192.168.1.0/24"},
+				RestartPolicy:         &rollingPolicy,
+				RebalanceStrategy:     &byCountStrategy,
+			},
+		},
+	}, nil)
+
+	stdout, _, err := testutil.Exec(t, env, "cluster", "describe", "clustercfg-id")
+	require.NoError(t, err)
+
+	assert.Contains(t, stdout, "Cluster Configuration:")
+	assert.Contains(t, stdout, "10.0.0.0/8, 192.168.1.0/24")
+	assert.Contains(t, stdout, "rolling")
+	assert.Contains(t, stdout, "by-count")
+}
+
+func TestDescribeCluster_Endpoint(t *testing.T) {
+	env := testutil.NewTestEnv(t)
+
+	env.Server.GetClusterCalls.Returns(&clusterv1.GetClusterResponse{
+		Cluster: &clusterv1.Cluster{
+			Id:   "endpoint-cluster",
+			Name: "endpoint",
+			State: &clusterv1.ClusterState{
+				Endpoint: &clusterv1.ClusterEndpoint{
+					Url:      "https://my-cluster.cloud.qdrant.io",
+					RestPort: 6333,
+					GrpcPort: 6334,
+				},
+			},
+		},
+	}, nil)
+
+	stdout, _, err := testutil.Exec(t, env, "cluster", "describe", "endpoint-cluster")
+	require.NoError(t, err)
+
+	assert.Contains(t, stdout, "https://my-cluster.cloud.qdrant.io")
+	assert.Contains(t, stdout, "6333")
+	assert.Contains(t, stdout, "6334")
+}
+
+func TestDescribeCluster_Resources(t *testing.T) {
+	env := testutil.NewTestEnv(t)
+
+	env.Server.GetClusterCalls.Returns(&clusterv1.GetClusterResponse{
+		Cluster: &clusterv1.Cluster{
+			Id:   "resources-cluster",
+			Name: "resources",
+			Configuration: &clusterv1.ClusterConfiguration{
+				ClusterStorageConfiguration: &clusterv1.ClusterStorageConfiguration{
+					StorageTierType: commonv1.StorageTierType_STORAGE_TIER_TYPE_PERFORMANCE,
+				},
+			},
+			State: &clusterv1.ClusterState{
+				Resources: &clusterv1.ClusterNodeResourcesSummary{
+					Disk: &clusterv1.ClusterNodeResources{
+						Base:      20.0,
+						Available: 18.5,
+					},
+					Ram: &clusterv1.ClusterNodeResources{
+						Base:      8.0,
+						Reserved:  1.6,
+						Available: 6.4,
+					},
+					Cpu: &clusterv1.ClusterNodeResources{
+						Base:      4000.0,
+						Reserved:  800.0,
+						Available: 3200.0,
+					},
+					Gpu: &clusterv1.ClusterNodeResources{
+						Base:      1000.0,
+						Reserved:  0.0,
+						Available: 1000.0,
+					},
+				},
+			},
+		},
+	}, nil)
+
+	stdout, _, err := testutil.Exec(t, env, "cluster", "describe", "resources-cluster")
+	require.NoError(t, err)
+
+	assert.Contains(t, stdout, "Resources (per node):")
+	assert.Contains(t, stdout, "20.00 GiB")
+	assert.Contains(t, stdout, "18.50 GiB")
+	assert.Contains(t, stdout, "performance")
+	assert.Contains(t, stdout, "8.00 GiB")
+	assert.Contains(t, stdout, "6.40 GiB")
+	assert.Contains(t, stdout, "4000m")
+	assert.Contains(t, stdout, "3200m")
+	assert.Contains(t, stdout, "1000m")
+}
+
+func TestDescribeCluster_Nodes(t *testing.T) {
+	env := testutil.NewTestEnv(t)
+
+	env.Server.GetClusterCalls.Returns(&clusterv1.GetClusterResponse{
+		Cluster: &clusterv1.Cluster{
+			Id:   "nodes-cluster",
+			Name: "nodes",
+			State: &clusterv1.ClusterState{
+				Nodes: []*clusterv1.ClusterNodeInfo{
+					{
+						Name:      "node-0",
+						State:     clusterv1.ClusterNodeState_CLUSTER_NODE_STATE_HEALTHY,
+						Version:   "1.13.0",
+						StartedAt: timestamppb.New(time.Now().Add(-2 * time.Hour)),
+					},
+					{
+						Name:    "node-1",
+						State:   clusterv1.ClusterNodeState_CLUSTER_NODE_STATE_HEALTHY,
+						Version: "1.13.0",
+					},
+				},
+			},
+		},
+	}, nil)
+
+	stdout, _, err := testutil.Exec(t, env, "cluster", "describe", "nodes-cluster")
+	require.NoError(t, err)
+
+	assert.Contains(t, stdout, "Nodes:")
+	assert.Contains(t, stdout, "node-0")
+	assert.Contains(t, stdout, "node-1")
+	assert.Contains(t, stdout, "HEALTHY")
+	assert.Contains(t, stdout, "1.13.0")
+	assert.Contains(t, stdout, "ago")
+}
+
+func TestDescribeCluster_JSONOutput(t *testing.T) {
+	env := testutil.NewTestEnv(t)
+
+	env.Server.GetClusterCalls.Returns(&clusterv1.GetClusterResponse{
+		Cluster: &clusterv1.Cluster{
+			Id:   "json-cluster",
+			Name: "json-name",
+		},
+	}, nil)
+
+	stdout, _, err := testutil.Exec(t, env, "cluster", "describe", "json-cluster", "--json")
+	require.NoError(t, err)
+
+	assert.Contains(t, stdout, `"id"`)
+	assert.Contains(t, stdout, `"json-cluster"`)
+	assert.Contains(t, stdout, `"json-name"`)
+}
+
+func TestDescribeCluster_AccountIDPassedToServer(t *testing.T) {
+	env := testutil.NewTestEnv(t)
+
+	env.Server.GetClusterCalls.Returns(&clusterv1.GetClusterResponse{
+		Cluster: &clusterv1.Cluster{Id: "any"},
+	}, nil)
+
+	_, _, err := testutil.Exec(t, env, "cluster", "describe", "any")
+	require.NoError(t, err)
+
+	req, ok := env.Server.GetClusterCalls.Last()
+	require.True(t, ok)
+	assert.Equal(t, "test-account-id", req.GetAccountId())
+}
+
+func TestDescribeCluster_ClusterIDPassedToServer(t *testing.T) {
+	env := testutil.NewTestEnv(t)
+
+	env.Server.GetClusterCalls.Returns(&clusterv1.GetClusterResponse{
+		Cluster: &clusterv1.Cluster{Id: "target-id"},
+	}, nil)
+
+	_, _, err := testutil.Exec(t, env, "cluster", "describe", "target-id")
+	require.NoError(t, err)
+
+	req, ok := env.Server.GetClusterCalls.Last()
+	require.True(t, ok)
+	assert.Equal(t, "target-id", req.GetClusterId())
+}
+
+func TestDescribeCluster_MissingArg(t *testing.T) {
+	env := testutil.NewTestEnv(t)
+
+	_, _, err := testutil.Exec(t, env, "cluster", "describe")
+	require.Error(t, err)
+}

--- a/internal/cmd/cluster/helpers.go
+++ b/internal/cmd/cluster/helpers.go
@@ -118,6 +118,32 @@ const (
 	rebalanceByCountAndSize = "by-count-and-size"
 )
 
+func restartPolicyString(p clusterv1.ClusterConfigurationRestartPolicy) string {
+	switch p {
+	case clusterv1.ClusterConfigurationRestartPolicy_CLUSTER_CONFIGURATION_RESTART_POLICY_ROLLING:
+		return restartModeRolling
+	case clusterv1.ClusterConfigurationRestartPolicy_CLUSTER_CONFIGURATION_RESTART_POLICY_PARALLEL:
+		return restartModeParallel
+	case clusterv1.ClusterConfigurationRestartPolicy_CLUSTER_CONFIGURATION_RESTART_POLICY_AUTOMATIC:
+		return restartModeAutomatic
+	default:
+		return ""
+	}
+}
+
+func rebalanceStrategyString(s clusterv1.ClusterConfigurationRebalanceStrategy) string {
+	switch s {
+	case clusterv1.ClusterConfigurationRebalanceStrategy_CLUSTER_CONFIGURATION_REBALANCE_STRATEGY_BY_COUNT:
+		return rebalanceByCount
+	case clusterv1.ClusterConfigurationRebalanceStrategy_CLUSTER_CONFIGURATION_REBALANCE_STRATEGY_BY_SIZE:
+		return rebalanceBySize
+	case clusterv1.ClusterConfigurationRebalanceStrategy_CLUSTER_CONFIGURATION_REBALANCE_STRATEGY_BY_COUNT_AND_SIZE:
+		return rebalanceByCountAndSize
+	default:
+		return ""
+	}
+}
+
 func parseRebalanceStrategy(s string) (clusterv1.ClusterConfigurationRebalanceStrategy, error) {
 	switch s {
 	case rebalanceByCount:

--- a/internal/cmd/cluster/helpers.go
+++ b/internal/cmd/cluster/helpers.go
@@ -92,3 +92,41 @@ func storageTierString(t commonv1.StorageTierType) string {
 		return ""
 	}
 }
+
+const (
+	restartModeRolling   = "rolling"
+	restartModeParallel  = "parallel"
+	restartModeAutomatic = "automatic"
+)
+
+func parseRestartMode(s string) (clusterv1.ClusterConfigurationRestartPolicy, error) {
+	switch s {
+	case restartModeRolling:
+		return clusterv1.ClusterConfigurationRestartPolicy_CLUSTER_CONFIGURATION_RESTART_POLICY_ROLLING, nil
+	case restartModeParallel:
+		return clusterv1.ClusterConfigurationRestartPolicy_CLUSTER_CONFIGURATION_RESTART_POLICY_PARALLEL, nil
+	case restartModeAutomatic:
+		return clusterv1.ClusterConfigurationRestartPolicy_CLUSTER_CONFIGURATION_RESTART_POLICY_AUTOMATIC, nil
+	default:
+		return clusterv1.ClusterConfigurationRestartPolicy_CLUSTER_CONFIGURATION_RESTART_POLICY_UNSPECIFIED, fmt.Errorf("invalid restart mode %q: must be one of %s, %s, %s", s, restartModeRolling, restartModeParallel, restartModeAutomatic)
+	}
+}
+
+const (
+	rebalanceByCount        = "by-count"
+	rebalanceBySize         = "by-size"
+	rebalanceByCountAndSize = "by-count-and-size"
+)
+
+func parseRebalanceStrategy(s string) (clusterv1.ClusterConfigurationRebalanceStrategy, error) {
+	switch s {
+	case rebalanceByCount:
+		return clusterv1.ClusterConfigurationRebalanceStrategy_CLUSTER_CONFIGURATION_REBALANCE_STRATEGY_BY_COUNT, nil
+	case rebalanceBySize:
+		return clusterv1.ClusterConfigurationRebalanceStrategy_CLUSTER_CONFIGURATION_REBALANCE_STRATEGY_BY_SIZE, nil
+	case rebalanceByCountAndSize:
+		return clusterv1.ClusterConfigurationRebalanceStrategy_CLUSTER_CONFIGURATION_REBALANCE_STRATEGY_BY_COUNT_AND_SIZE, nil
+	default:
+		return clusterv1.ClusterConfigurationRebalanceStrategy_CLUSTER_CONFIGURATION_REBALANCE_STRATEGY_UNSPECIFIED, fmt.Errorf("invalid rebalance strategy %q: must be one of %s, %s, %s", s, rebalanceByCount, rebalanceBySize, rebalanceByCountAndSize)
+	}
+}

--- a/internal/cmd/cluster/scale.go
+++ b/internal/cmd/cluster/scale.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/qdrant/qcloud-cli/internal/cmd/base"
 	"github.com/qdrant/qcloud-cli/internal/cmd/completion"
+	"github.com/qdrant/qcloud-cli/internal/cmd/output"
 	"github.com/qdrant/qcloud-cli/internal/cmd/util"
 	"github.com/qdrant/qcloud-cli/internal/resource"
 	"github.com/qdrant/qcloud-cli/internal/state"
@@ -302,14 +303,6 @@ match.`,
 	return cmd
 }
 
-// scaleDiff formats a field value as "old => new" when the value changes, or just "val" when unchanged.
-func scaleDiff(oldVal, newVal string) string {
-	if oldVal == newVal {
-		return newVal
-	}
-	return oldVal + " => " + newVal
-}
-
 // scaleConfirmPrompt builds the confirmation message shown before a scale operation,
 // displaying old => new for fields that are changing.
 func scaleConfirmPrompt(
@@ -323,24 +316,24 @@ func scaleConfirmPrompt(
 	oldRC := oldPkg.GetResourceConfiguration()
 	newRC := newPkg.GetResourceConfiguration()
 
-	diskLine := scaleDiff(currentTotalDisk.String(), newEffectiveDisk.String())
+	diskLine := output.DiffValue(currentTotalDisk.String(), newEffectiveDisk.String())
 	if diskWillBeOverridden {
-		diskLine = fmt.Sprintf("%s (requested: %s - package minimum disk is being applied)", scaleDiff(currentTotalDisk.String(), newEffectiveDisk.String()), requestedDisk)
+		diskLine = fmt.Sprintf("%s (requested: %s - package minimum disk is being applied)", output.DiffValue(currentTotalDisk.String(), newEffectiveDisk.String()), requestedDisk)
 	}
 
 	prompt := fmt.Sprintf(
 		"Cluster %s (%s) will be scaled to:\n  Nodes:   %s\n  CPU:     %s\n  RAM:     %s\n  Disk:    %s",
 		cluster.GetId(), cluster.GetName(),
-		scaleDiff(fmt.Sprintf("%d", oldNodes), fmt.Sprintf("%d", cluster.Configuration.NumberOfNodes)),
-		scaleDiff(oldRC.GetCpu(), newRC.GetCpu()),
-		scaleDiff(oldRC.GetRam(), newRC.GetRam()),
+		output.DiffValue(fmt.Sprintf("%d", oldNodes), fmt.Sprintf("%d", cluster.Configuration.NumberOfNodes)),
+		output.DiffValue(oldRC.GetCpu(), newRC.GetCpu()),
+		output.DiffValue(oldRC.GetRam(), newRC.GetRam()),
 		diskLine,
 	)
 	if oldRC.GetGpu() != "" || newRC.GetGpu() != "" {
-		prompt += fmt.Sprintf("\n  GPU:     %s", scaleDiff(oldRC.GetGpu(), newRC.GetGpu()))
+		prompt += fmt.Sprintf("\n  GPU:     %s", output.DiffValue(oldRC.GetGpu(), newRC.GetGpu()))
 	}
 	if oldStorageTier != "" || newStorageTier != "" {
-		prompt += fmt.Sprintf("\n  Storage tier: %s", scaleDiff(oldStorageTier, newStorageTier))
+		prompt += fmt.Sprintf("\n  Storage tier: %s", output.DiffValue(oldStorageTier, newStorageTier))
 	}
 	prompt += "\nProceed?"
 	return prompt

--- a/internal/cmd/cluster/update.go
+++ b/internal/cmd/cluster/update.go
@@ -3,6 +3,8 @@ package cluster
 import (
 	"fmt"
 	"io"
+	"slices"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -15,15 +17,43 @@ import (
 	"github.com/qdrant/qcloud-cli/internal/state"
 )
 
+// dbConfigFlags lists flags that trigger a rolling restart.
+var dbConfigFlags = []string{
+	"replication-factor",
+	"write-consistency-factor",
+	"async-scorer",
+	"optimizer-cpu-budget",
+}
+
 func newUpdateCommand(s *state.State) *cobra.Command {
-	return base.UpdateCmd[*clusterv1.Cluster]{
+	cmd := base.UpdateCmd[*clusterv1.Cluster]{
 		BaseCobraCommand: func() *cobra.Command {
 			cmd := &cobra.Command{
 				Use:   "update <cluster-id>",
 				Short: "Update an existing cluster",
-				Args:  util.ExactArgs(1, "a cluster ID"),
+				Long: `Updates the configuration of a cluster.
+
+Use this command to modify cluster settings such as labels, database defaults,
+IP restrictions, restart mode, and rebalance strategy.
+
+Database configuration changes (--replication-factor, --write-consistency-factor,
+--async-scorer, --optimizer-cpu-budget) will trigger a rolling restart of the
+cluster. The cluster remains available during the restart, but individual nodes
+will be briefly unavailable as they cycle.
+
+Cluster configuration changes (--allowed-ips, --restart-mode, --rebalance-strategy)
+and label changes take effect without a restart.`,
+				Args: util.ExactArgs(1, "a cluster ID"),
 			}
 			cmd.Flags().StringToString("label", nil, "Label to apply to the cluster ('key=value'), can be specified multiple times; replaces all existing labels")
+			cmd.Flags().Uint32("replication-factor", 0, "Default replication factor for new collections")
+			cmd.Flags().Int32("write-consistency-factor", 0, "Default write consistency factor for new collections")
+			cmd.Flags().Bool("async-scorer", false, "Enable async scorer (uses io_uring on Linux)")
+			cmd.Flags().Int32("optimizer-cpu-budget", 0, `CPU threads for optimization (0=auto, negative=subtract from available CPUs, positive=exact count)`)
+			cmd.Flags().StringSlice("allowed-ips", nil, "Allowed client IP CIDR ranges (replaces all existing); max 20")
+			cmd.Flags().String("restart-mode", "", `Restart policy ("rolling", "parallel", "automatic")`)
+			cmd.Flags().String("rebalance-strategy", "", `Shard rebalance strategy ("by-count", "by-size", "by-count-and-size")`)
+			cmd.Flags().BoolP("force", "f", false, "Skip confirmation prompt")
 			return cmd
 		},
 		Fetch: func(s *state.State, cmd *cobra.Command, args []string) (*clusterv1.Cluster, error) {
@@ -55,11 +85,98 @@ func newUpdateCommand(s *state.State) *cobra.Command {
 				return nil, err
 			}
 
-			labelMap, _ := cmd.Flags().GetStringToString("label")
-			cluster.Labels = nil
-			for k, v := range labelMap {
-				cluster.Labels = append(cluster.Labels, &commonv1.KeyValue{Key: k, Value: v})
+			// Labels
+			if cmd.Flags().Changed("label") {
+				labelMap, _ := cmd.Flags().GetStringToString("label")
+				cluster.Labels = nil
+				for k, v := range labelMap {
+					cluster.Labels = append(cluster.Labels, &commonv1.KeyValue{Key: k, Value: v})
+				}
 			}
+
+			// Ensure configuration exists
+			if cluster.Configuration == nil {
+				cluster.Configuration = &clusterv1.ClusterConfiguration{}
+			}
+			cfg := cluster.Configuration
+
+			// --- Database configuration flags (trigger rolling restart) ---
+
+			dbChanged := slices.ContainsFunc(dbConfigFlags, func(f string) bool {
+				return cmd.Flags().Changed(f)
+			})
+
+			if dbChanged {
+				if cfg.DatabaseConfiguration == nil {
+					cfg.DatabaseConfiguration = &clusterv1.DatabaseConfiguration{}
+				}
+				dbCfg := cfg.DatabaseConfiguration
+
+				if cmd.Flags().Changed("replication-factor") || cmd.Flags().Changed("write-consistency-factor") {
+					if dbCfg.Collection == nil {
+						dbCfg.Collection = &clusterv1.DatabaseConfigurationCollection{}
+					}
+					if cmd.Flags().Changed("replication-factor") {
+						v, _ := cmd.Flags().GetUint32("replication-factor")
+						dbCfg.Collection.ReplicationFactor = &v
+					}
+					if cmd.Flags().Changed("write-consistency-factor") {
+						v, _ := cmd.Flags().GetInt32("write-consistency-factor")
+						dbCfg.Collection.WriteConsistencyFactor = &v
+					}
+				}
+
+				if cmd.Flags().Changed("async-scorer") || cmd.Flags().Changed("optimizer-cpu-budget") {
+					if dbCfg.Storage == nil {
+						dbCfg.Storage = &clusterv1.DatabaseConfigurationStorage{}
+					}
+					if dbCfg.Storage.Performance == nil {
+						dbCfg.Storage.Performance = &clusterv1.DatabaseConfigurationStoragePerformance{}
+					}
+					if cmd.Flags().Changed("async-scorer") {
+						v, _ := cmd.Flags().GetBool("async-scorer")
+						dbCfg.Storage.Performance.AsyncScorer = &v
+					}
+					if cmd.Flags().Changed("optimizer-cpu-budget") {
+						v, _ := cmd.Flags().GetInt32("optimizer-cpu-budget")
+						dbCfg.Storage.Performance.OptimizerCpuBudget = &v
+					}
+				}
+
+				// Confirmation prompt for rolling restart
+				force, _ := cmd.Flags().GetBool("force")
+				prompt := updateDBConfigPrompt(cluster, cmd)
+				if !util.ConfirmAction(force, prompt) {
+					fmt.Fprintln(cmd.OutOrStdout(), "Aborted.")
+					return nil, nil
+				}
+			}
+
+			// --- Cluster configuration flags (no restart) ---
+
+			if cmd.Flags().Changed("allowed-ips") {
+				ips, _ := cmd.Flags().GetStringSlice("allowed-ips")
+				cfg.AllowedIpSourceRanges = ips
+			}
+
+			if cmd.Flags().Changed("restart-mode") {
+				modeStr, _ := cmd.Flags().GetString("restart-mode")
+				mode, err := parseRestartMode(modeStr)
+				if err != nil {
+					return nil, err
+				}
+				cfg.RestartPolicy = mode.Enum()
+			}
+
+			if cmd.Flags().Changed("rebalance-strategy") {
+				stratStr, _ := cmd.Flags().GetString("rebalance-strategy")
+				strat, err := parseRebalanceStrategy(stratStr)
+				if err != nil {
+					return nil, err
+				}
+				cfg.RebalanceStrategy = strat.Enum()
+			}
+
 			resp, err := client.Cluster().UpdateCluster(ctx, &clusterv1.UpdateClusterRequest{
 				Cluster: cluster,
 			})
@@ -70,8 +187,44 @@ func newUpdateCommand(s *state.State) *cobra.Command {
 			return resp.GetCluster(), nil
 		},
 		PrintResource: func(_ *cobra.Command, out io.Writer, updated *clusterv1.Cluster) {
+			if updated == nil {
+				return
+			}
 			fmt.Fprintf(out, "Cluster %s (%s) updated successfully.\n", updated.GetId(), updated.GetName())
 		},
 		ValidArgsFunction: completion.ClusterIDCompletion(s),
 	}.CobraCommand(s)
+
+	_ = cmd.RegisterFlagCompletionFunc("restart-mode", restartModeCompletion())
+	_ = cmd.RegisterFlagCompletionFunc("rebalance-strategy", rebalanceStrategyCompletion())
+	return cmd
+}
+
+// updateDBConfigPrompt builds the confirmation message shown when database
+// configuration flags are changed, warning about the rolling restart.
+func updateDBConfigPrompt(cluster *clusterv1.Cluster, cmd *cobra.Command) string {
+	var lines []string
+	lines = append(lines, fmt.Sprintf("Updating cluster %s (%s) will change:", cluster.GetId(), cluster.GetName()))
+
+	if cmd.Flags().Changed("replication-factor") {
+		v, _ := cmd.Flags().GetUint32("replication-factor")
+		lines = append(lines, fmt.Sprintf("  Replication factor:        %d", v))
+	}
+	if cmd.Flags().Changed("write-consistency-factor") {
+		v, _ := cmd.Flags().GetInt32("write-consistency-factor")
+		lines = append(lines, fmt.Sprintf("  Write consistency factor:  %d", v))
+	}
+	if cmd.Flags().Changed("async-scorer") {
+		v, _ := cmd.Flags().GetBool("async-scorer")
+		lines = append(lines, fmt.Sprintf("  Async scorer:              %s", boolToYesNo(v)))
+	}
+	if cmd.Flags().Changed("optimizer-cpu-budget") {
+		v, _ := cmd.Flags().GetInt32("optimizer-cpu-budget")
+		lines = append(lines, fmt.Sprintf("  Optimizer CPU budget:      %d", v))
+	}
+
+	lines = append(lines, "")
+	lines = append(lines, "WARNING: Database configuration changes will result in a rolling restart of your cluster.")
+	lines = append(lines, "Proceed?")
+	return strings.Join(lines, "\n")
 }

--- a/internal/cmd/cluster/update.go
+++ b/internal/cmd/cluster/update.go
@@ -7,12 +7,14 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
+	"google.golang.org/protobuf/proto"
 
 	clusterv1 "github.com/qdrant/qdrant-cloud-public-api/gen/go/qdrant/cloud/cluster/v1"
 	commonv1 "github.com/qdrant/qdrant-cloud-public-api/gen/go/qdrant/cloud/common/v1"
 
 	"github.com/qdrant/qcloud-cli/internal/cmd/base"
 	"github.com/qdrant/qcloud-cli/internal/cmd/completion"
+	"github.com/qdrant/qcloud-cli/internal/cmd/output"
 	"github.com/qdrant/qcloud-cli/internal/cmd/util"
 	"github.com/qdrant/qcloud-cli/internal/state"
 )
@@ -85,20 +87,22 @@ and label changes take effect without a restart.`,
 				return nil, err
 			}
 
+			updated := proto.CloneOf(cluster)
+
 			// Labels
 			if cmd.Flags().Changed("label") {
 				labelMap, _ := cmd.Flags().GetStringToString("label")
-				cluster.Labels = nil
+				updated.Labels = nil
 				for k, v := range labelMap {
-					cluster.Labels = append(cluster.Labels, &commonv1.KeyValue{Key: k, Value: v})
+					updated.Labels = append(updated.Labels, &commonv1.KeyValue{Key: k, Value: v})
 				}
 			}
 
 			// Ensure configuration exists
-			if cluster.Configuration == nil {
-				cluster.Configuration = &clusterv1.ClusterConfiguration{}
+			if updated.Configuration == nil {
+				updated.Configuration = &clusterv1.ClusterConfiguration{}
 			}
-			cfg := cluster.Configuration
+			cfg := updated.Configuration
 
 			// --- Database configuration flags (trigger rolling restart) ---
 
@@ -145,7 +149,7 @@ and label changes take effect without a restart.`,
 
 				// Confirmation prompt for rolling restart
 				force, _ := cmd.Flags().GetBool("force")
-				prompt := updateDBConfigPrompt(cluster, cmd)
+				prompt := updateDBConfigPrompt(cluster, updated, cmd)
 				if !util.ConfirmAction(force, prompt) {
 					fmt.Fprintln(cmd.OutOrStdout(), "Aborted.")
 					return nil, nil
@@ -178,7 +182,7 @@ and label changes take effect without a restart.`,
 			}
 
 			resp, err := client.Cluster().UpdateCluster(ctx, &clusterv1.UpdateClusterRequest{
-				Cluster: cluster,
+				Cluster: updated,
 			})
 			if err != nil {
 				return nil, fmt.Errorf("failed to update cluster: %w", err)
@@ -202,25 +206,46 @@ and label changes take effect without a restart.`,
 
 // updateDBConfigPrompt builds the confirmation message shown when database
 // configuration flags are changed, warning about the rolling restart.
-func updateDBConfigPrompt(cluster *clusterv1.Cluster, cmd *cobra.Command) string {
+// It compares old (before mutation) and updated (after mutation) cluster objects
+// to display a diff of each changed field.
+func updateDBConfigPrompt(old, updated *clusterv1.Cluster, cmd *cobra.Command) string {
 	var lines []string
-	lines = append(lines, fmt.Sprintf("Updating cluster %s (%s) will change:", cluster.GetId(), cluster.GetName()))
+	lines = append(lines, fmt.Sprintf("Updating cluster %s (%s) will change:", old.GetId(), old.GetName()))
+
+	oldCol := old.GetConfiguration().GetDatabaseConfiguration().GetCollection()
+	newCol := updated.GetConfiguration().GetDatabaseConfiguration().GetCollection()
+	oldPerf := old.GetConfiguration().GetDatabaseConfiguration().GetStorage().GetPerformance()
+	newPerf := updated.GetConfiguration().GetDatabaseConfiguration().GetStorage().GetPerformance()
+
+	notSet := "(not set)"
 
 	if cmd.Flags().Changed("replication-factor") {
-		v, _ := cmd.Flags().GetUint32("replication-factor")
-		lines = append(lines, fmt.Sprintf("  Replication factor:        %d", v))
+		var oldRF *uint32
+		if oldCol != nil {
+			oldRF = oldCol.ReplicationFactor
+		}
+		lines = append(lines, fmt.Sprintf("  Replication factor:        %s", output.DiffValue(output.OptionalValue(oldRF, notSet), fmt.Sprintf("%d", newCol.GetReplicationFactor()))))
 	}
 	if cmd.Flags().Changed("write-consistency-factor") {
-		v, _ := cmd.Flags().GetInt32("write-consistency-factor")
-		lines = append(lines, fmt.Sprintf("  Write consistency factor:  %d", v))
+		var oldWCF *int32
+		if oldCol != nil {
+			oldWCF = oldCol.WriteConsistencyFactor
+		}
+		lines = append(lines, fmt.Sprintf("  Write consistency factor:  %s", output.DiffValue(output.OptionalValue(oldWCF, notSet), fmt.Sprintf("%d", newCol.GetWriteConsistencyFactor()))))
 	}
 	if cmd.Flags().Changed("async-scorer") {
-		v, _ := cmd.Flags().GetBool("async-scorer")
-		lines = append(lines, fmt.Sprintf("  Async scorer:              %s", boolToYesNo(v)))
+		var oldAS *bool
+		if oldPerf != nil {
+			oldAS = oldPerf.AsyncScorer
+		}
+		lines = append(lines, fmt.Sprintf("  Async scorer:              %s", output.DiffValue(output.OptionalValue(oldAS, notSet), boolToYesNo(newPerf.GetAsyncScorer()))))
 	}
 	if cmd.Flags().Changed("optimizer-cpu-budget") {
-		v, _ := cmd.Flags().GetInt32("optimizer-cpu-budget")
-		lines = append(lines, fmt.Sprintf("  Optimizer CPU budget:      %d", v))
+		var oldBudget *int32
+		if oldPerf != nil {
+			oldBudget = oldPerf.OptimizerCpuBudget
+		}
+		lines = append(lines, fmt.Sprintf("  Optimizer CPU budget:      %s", output.DiffValue(output.OptionalValue(oldBudget, notSet), fmt.Sprintf("%d", newPerf.GetOptimizerCpuBudget()))))
 	}
 
 	lines = append(lines, "")

--- a/internal/cmd/cluster/update_test.go
+++ b/internal/cmd/cluster/update_test.go
@@ -81,3 +81,222 @@ func TestUpdateCluster_APIError(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to update cluster")
 }
+
+func TestUpdateCluster_ReplicationFactor(t *testing.T) {
+	env := testutil.NewTestEnv(t)
+	setupUpdateHandlers(env)
+
+	stdout, _, err := testutil.Exec(t, env,
+		"cluster", "update", "cluster-abc",
+		"--replication-factor", "3",
+		"--force",
+	)
+	require.NoError(t, err)
+	assert.Contains(t, stdout, "updated successfully")
+
+	req, ok := env.Server.UpdateClusterCalls.Last()
+	require.True(t, ok)
+	rf := req.GetCluster().GetConfiguration().GetDatabaseConfiguration().GetCollection().GetReplicationFactor()
+	assert.Equal(t, uint32(3), rf)
+}
+
+func TestUpdateCluster_WriteConsistencyFactor(t *testing.T) {
+	env := testutil.NewTestEnv(t)
+	setupUpdateHandlers(env)
+
+	stdout, _, err := testutil.Exec(t, env,
+		"cluster", "update", "cluster-abc",
+		"--write-consistency-factor", "2",
+		"--force",
+	)
+	require.NoError(t, err)
+	assert.Contains(t, stdout, "updated successfully")
+
+	req, ok := env.Server.UpdateClusterCalls.Last()
+	require.True(t, ok)
+	wcf := req.GetCluster().GetConfiguration().GetDatabaseConfiguration().GetCollection().GetWriteConsistencyFactor()
+	assert.Equal(t, int32(2), wcf)
+}
+
+func TestUpdateCluster_AsyncScorer(t *testing.T) {
+	env := testutil.NewTestEnv(t)
+	setupUpdateHandlers(env)
+
+	stdout, _, err := testutil.Exec(t, env,
+		"cluster", "update", "cluster-abc",
+		"--async-scorer",
+		"--force",
+	)
+	require.NoError(t, err)
+	assert.Contains(t, stdout, "updated successfully")
+
+	req, ok := env.Server.UpdateClusterCalls.Last()
+	require.True(t, ok)
+	as := req.GetCluster().GetConfiguration().GetDatabaseConfiguration().GetStorage().GetPerformance().GetAsyncScorer()
+	assert.True(t, as)
+}
+
+func TestUpdateCluster_OptimizerCPUBudget(t *testing.T) {
+	env := testutil.NewTestEnv(t)
+	setupUpdateHandlers(env)
+
+	stdout, _, err := testutil.Exec(t, env,
+		"cluster", "update", "cluster-abc",
+		"--optimizer-cpu-budget", "4",
+		"--force",
+	)
+	require.NoError(t, err)
+	assert.Contains(t, stdout, "updated successfully")
+
+	req, ok := env.Server.UpdateClusterCalls.Last()
+	require.True(t, ok)
+	budget := req.GetCluster().GetConfiguration().GetDatabaseConfiguration().GetStorage().GetPerformance().GetOptimizerCpuBudget()
+	assert.Equal(t, int32(4), budget)
+}
+
+func TestUpdateCluster_AllowedIPs(t *testing.T) {
+	env := testutil.NewTestEnv(t)
+	setupUpdateHandlers(env)
+
+	stdout, _, err := testutil.Exec(t, env,
+		"cluster", "update", "cluster-abc",
+		"--allowed-ips", "10.0.0.0/8,172.16.0.0/12",
+	)
+	require.NoError(t, err)
+	assert.Contains(t, stdout, "updated successfully")
+
+	req, ok := env.Server.UpdateClusterCalls.Last()
+	require.True(t, ok)
+	ips := req.GetCluster().GetConfiguration().GetAllowedIpSourceRanges()
+	assert.Equal(t, []string{"10.0.0.0/8", "172.16.0.0/12"}, ips)
+}
+
+func TestUpdateCluster_RestartMode(t *testing.T) {
+	env := testutil.NewTestEnv(t)
+	setupUpdateHandlers(env)
+
+	stdout, _, err := testutil.Exec(t, env,
+		"cluster", "update", "cluster-abc",
+		"--restart-mode", "parallel",
+	)
+	require.NoError(t, err)
+	assert.Contains(t, stdout, "updated successfully")
+
+	req, ok := env.Server.UpdateClusterCalls.Last()
+	require.True(t, ok)
+	rp := req.GetCluster().GetConfiguration().GetRestartPolicy()
+	assert.Equal(t, clusterv1.ClusterConfigurationRestartPolicy_CLUSTER_CONFIGURATION_RESTART_POLICY_PARALLEL, rp)
+}
+
+func TestUpdateCluster_RebalanceStrategy(t *testing.T) {
+	env := testutil.NewTestEnv(t)
+	setupUpdateHandlers(env)
+
+	stdout, _, err := testutil.Exec(t, env,
+		"cluster", "update", "cluster-abc",
+		"--rebalance-strategy", "by-count-and-size",
+	)
+	require.NoError(t, err)
+	assert.Contains(t, stdout, "updated successfully")
+
+	req, ok := env.Server.UpdateClusterCalls.Last()
+	require.True(t, ok)
+	rs := req.GetCluster().GetConfiguration().GetRebalanceStrategy()
+	assert.Equal(t, clusterv1.ClusterConfigurationRebalanceStrategy_CLUSTER_CONFIGURATION_REBALANCE_STRATEGY_BY_COUNT_AND_SIZE, rs)
+}
+
+func TestUpdateCluster_InvalidRestartMode(t *testing.T) {
+	env := testutil.NewTestEnv(t)
+	setupUpdateHandlers(env)
+
+	_, _, err := testutil.Exec(t, env,
+		"cluster", "update", "cluster-abc",
+		"--restart-mode", "invalid",
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid restart mode")
+}
+
+func TestUpdateCluster_InvalidRebalanceStrategy(t *testing.T) {
+	env := testutil.NewTestEnv(t)
+	setupUpdateHandlers(env)
+
+	_, _, err := testutil.Exec(t, env,
+		"cluster", "update", "cluster-abc",
+		"--rebalance-strategy", "invalid",
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid rebalance strategy")
+}
+
+func TestUpdateCluster_MultipleDBConfigFlags(t *testing.T) {
+	env := testutil.NewTestEnv(t)
+	setupUpdateHandlers(env)
+
+	stdout, _, err := testutil.Exec(t, env,
+		"cluster", "update", "cluster-abc",
+		"--replication-factor", "3",
+		"--write-consistency-factor", "2",
+		"--async-scorer",
+		"--optimizer-cpu-budget", "-1",
+		"--force",
+	)
+	require.NoError(t, err)
+	assert.Contains(t, stdout, "updated successfully")
+
+	req, ok := env.Server.UpdateClusterCalls.Last()
+	require.True(t, ok)
+	cluster := req.GetCluster()
+	dbCfg := cluster.GetConfiguration().GetDatabaseConfiguration()
+	assert.Equal(t, uint32(3), dbCfg.GetCollection().GetReplicationFactor())
+	assert.Equal(t, int32(2), dbCfg.GetCollection().GetWriteConsistencyFactor())
+	assert.True(t, dbCfg.GetStorage().GetPerformance().GetAsyncScorer())
+	assert.Equal(t, int32(-1), dbCfg.GetStorage().GetPerformance().GetOptimizerCpuBudget())
+}
+
+func TestUpdateCluster_PreservesExistingConfig(t *testing.T) {
+	env := testutil.NewTestEnv(t)
+
+	env.Server.GetClusterCalls.Always(func(_ context.Context, req *clusterv1.GetClusterRequest) (*clusterv1.GetClusterResponse, error) {
+		existing := clusterv1.ClusterConfigurationRebalanceStrategy_CLUSTER_CONFIGURATION_REBALANCE_STRATEGY_BY_SIZE
+		return &clusterv1.GetClusterResponse{
+			Cluster: &clusterv1.Cluster{
+				Id:   req.GetClusterId(),
+				Name: "my-cluster",
+				Configuration: &clusterv1.ClusterConfiguration{
+					AllowedIpSourceRanges: []string{"10.0.0.0/8"},
+					RebalanceStrategy:     &existing,
+				},
+			},
+		}, nil
+	})
+	env.Server.UpdateClusterCalls.Always(func(_ context.Context, req *clusterv1.UpdateClusterRequest) (*clusterv1.UpdateClusterResponse, error) {
+		return &clusterv1.UpdateClusterResponse{Cluster: req.GetCluster()}, nil
+	})
+
+	// Only change restart-mode, everything else should be preserved
+	_, _, err := testutil.Exec(t, env,
+		"cluster", "update", "cluster-abc",
+		"--restart-mode", "rolling",
+	)
+	require.NoError(t, err)
+
+	req, ok := env.Server.UpdateClusterCalls.Last()
+	require.True(t, ok)
+	cfg := req.GetCluster().GetConfiguration()
+	assert.Equal(t, []string{"10.0.0.0/8"}, cfg.GetAllowedIpSourceRanges())
+	assert.Equal(t, clusterv1.ClusterConfigurationRebalanceStrategy_CLUSTER_CONFIGURATION_REBALANCE_STRATEGY_BY_SIZE, cfg.GetRebalanceStrategy())
+	assert.Equal(t, clusterv1.ClusterConfigurationRestartPolicy_CLUSTER_CONFIGURATION_RESTART_POLICY_ROLLING, cfg.GetRestartPolicy())
+}
+
+// setupUpdateHandlers configures the standard Get/Update handlers for update tests.
+func setupUpdateHandlers(env *testutil.TestEnv) {
+	env.Server.GetClusterCalls.Always(func(_ context.Context, req *clusterv1.GetClusterRequest) (*clusterv1.GetClusterResponse, error) {
+		return &clusterv1.GetClusterResponse{
+			Cluster: &clusterv1.Cluster{Id: req.GetClusterId(), Name: "my-cluster"},
+		}, nil
+	})
+	env.Server.UpdateClusterCalls.Always(func(_ context.Context, req *clusterv1.UpdateClusterRequest) (*clusterv1.UpdateClusterResponse, error) {
+		return &clusterv1.UpdateClusterResponse{Cluster: req.GetCluster()}, nil
+	})
+}

--- a/internal/cmd/output/format.go
+++ b/internal/cmd/output/format.go
@@ -1,6 +1,7 @@
 package output
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/dustin/go-humanize"
@@ -22,4 +23,39 @@ func FullDateTime(t time.Time) string {
 		return ""
 	}
 	return t.UTC().Format("2006-01-02 15:04:05 UTC")
+}
+
+// DiffValue formats a field value as "old => new" when the value changes, or just "val" when unchanged.
+func DiffValue(oldVal, newVal string) string {
+	if oldVal == newVal {
+		return newVal
+	}
+	return oldVal + " => " + newVal
+}
+
+// OptionalValue formats an optional pointer value as a string.
+// Returns fallback for nil pointers. Supports *uint32, *int32, and *bool.
+func OptionalValue(v any, fallback string) string {
+	switch val := v.(type) {
+	case *uint32:
+		if val == nil {
+			return fallback
+		}
+		return fmt.Sprintf("%d", *val)
+	case *int32:
+		if val == nil {
+			return fallback
+		}
+		return fmt.Sprintf("%d", *val)
+	case *bool:
+		if val == nil {
+			return fallback
+		}
+		if *val {
+			return "yes"
+		}
+		return "no"
+	default:
+		return fallback
+	}
 }

--- a/internal/cmd/output/format.go
+++ b/internal/cmd/output/format.go
@@ -2,6 +2,7 @@ package output
 
 import (
 	"fmt"
+	"reflect"
 	"time"
 
 	"github.com/dustin/go-humanize"
@@ -30,32 +31,26 @@ func DiffValue(oldVal, newVal string) string {
 	if oldVal == newVal {
 		return newVal
 	}
+
 	return oldVal + " => " + newVal
 }
 
 // OptionalValue formats an optional pointer value as a string.
-// Returns fallback for nil pointers. Supports *uint32, *int32, and *bool.
+// Returns fallback for nil pointers. Supports any pointer type.
+// Booleans are formatted as "yes"/"no"; all other types use their default format.
 func OptionalValue(v any, fallback string) string {
-	switch val := v.(type) {
-	case *uint32:
-		if val == nil {
-			return fallback
-		}
-		return fmt.Sprintf("%d", *val)
-	case *int32:
-		if val == nil {
-			return fallback
-		}
-		return fmt.Sprintf("%d", *val)
-	case *bool:
-		if val == nil {
-			return fallback
-		}
-		if *val {
+	rv := reflect.ValueOf(v)
+	if !rv.IsValid() || rv.Kind() != reflect.Pointer || rv.IsNil() {
+		return fallback
+	}
+
+	elem := rv.Elem().Interface()
+	if b, ok := elem.(bool); ok {
+		if b {
 			return "yes"
 		}
 		return "no"
-	default:
-		return fallback
 	}
+
+	return fmt.Sprintf("%v", elem)
 }


### PR DESCRIPTION
- Add database configuration parameters to the `cluster update` command: `--replication-factor`, `--write-consistency-factor`, `--restart-mode`, `--rebalance-strategy`, and `--optimizer-indexing-threshold`
- Shell completions for `--restart-mode` and `--rebalance-strategy` flags with valid values
- Confirmation prompt showing a diff of old vs new values before applying changes (skippable with `--force`)
- Move shared formatting utilities (`DiffValue`, `OptionalValue`) to the `output` package for reuse across commands.

The `cluster update` command previously only supported updating labels. This PR extends it to support modifying database configuration fields via the Qdrant Cloud API. Each flag is independently optional, and only changed fields are included in the update request.

A confirmation prompt displays the current and proposed values in an `old => new` format before proceeding, consistent with the existing `cluster scale` command UX. The `--force` flag bypasses the prompt for scripting use cases.

The `scaleDiff` helper was generalized into `output.DiffValue` and moved to the `output` package, replacing the local copy in `scale.go`.