### PR TITLE
fix: rework --label on cluster update to add/update and remove instead

### DIFF
--- a/internal/cmd/cluster/create.go
+++ b/internal/cmd/cluster/create.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/qdrant/qcloud-cli/internal/cmd/base"
 	"github.com/qdrant/qcloud-cli/internal/cmd/completion"
+	"github.com/qdrant/qcloud-cli/internal/cmd/util"
 	"github.com/qdrant/qcloud-cli/internal/resource"
 	"github.com/qdrant/qcloud-cli/internal/state"
 )
@@ -36,7 +37,7 @@ func newCreateCommand(s *state.State) *cobra.Command {
 			cmd.Flags().Var(new(resource.ByteQuantity), "disk", "Total disk size (e.g. \"200GiB\"); if larger than the package's included disk, the difference is provisioned as additional storage")
 			cmd.Flags().Var(new(resource.Millicores), "gpu", "Number of GPUs to select a package (e.g. \"1\", \"2\", or \"1000m\")")
 			cmd.Flags().Bool("multi-az", false, "Require a multi-AZ package")
-			cmd.Flags().StringToString("label", nil, "Label to apply to the cluster ('key=value'), can be specified multiple times")
+			cmd.Flags().StringArray("label", nil, "Label to apply to the cluster ('key=value'), can be specified multiple times")
 			cmd.Flags().Bool("wait", false, "Wait for the cluster to become healthy")
 			cmd.Flags().Duration("wait-timeout", 10*time.Minute, "Maximum time to wait for cluster health")
 			cmd.Flags().Duration("wait-poll-interval", 5*time.Second, "How often to poll for cluster health")
@@ -81,7 +82,7 @@ func newCreateCommand(s *state.State) *cobra.Command {
 			nodes, _ := cmd.Flags().GetUint32("nodes")
 			packageValue, _ := cmd.Flags().GetString("package")
 			multiAz, _ := cmd.Flags().GetBool("multi-az")
-			labelMap, _ := cmd.Flags().GetStringToString("label")
+			rawLabels, _ := cmd.Flags().GetStringArray("label")
 
 			cpuChanged := cmd.Flags().Changed("cpu")
 			ramChanged := cmd.Flags().Changed("ram")
@@ -145,7 +146,11 @@ func newCreateCommand(s *state.State) *cobra.Command {
 			if packageID != "" {
 				cluster.Configuration.PackageId = packageID
 			}
-			for k, v := range labelMap {
+			labelChanges, err := util.ParseLabels(rawLabels)
+			if err != nil {
+				return nil, err
+			}
+			for k, v := range labelChanges.Set {
 				cluster.Labels = append(cluster.Labels, &commonv1.KeyValue{Key: k, Value: v})
 			}
 

--- a/internal/cmd/cluster/update.go
+++ b/internal/cmd/cluster/update.go
@@ -98,7 +98,7 @@ overwrite a label, and 'key-' (with a trailing dash) to remove one.`,
 				if err != nil {
 					return nil, err
 				}
-				updated.Labels = util.MergeLabels(updated.Labels, changes)
+				updated.Labels = util.ApplyLabels(updated.Labels, changes)
 			}
 
 			// Ensure configuration exists

--- a/internal/cmd/cluster/update.go
+++ b/internal/cmd/cluster/update.go
@@ -10,7 +10,6 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	clusterv1 "github.com/qdrant/qdrant-cloud-public-api/gen/go/qdrant/cloud/cluster/v1"
-	commonv1 "github.com/qdrant/qdrant-cloud-public-api/gen/go/qdrant/cloud/common/v1"
 
 	"github.com/qdrant/qcloud-cli/internal/cmd/base"
 	"github.com/qdrant/qcloud-cli/internal/cmd/completion"
@@ -44,10 +43,13 @@ cluster. The cluster remains available during the restart, but individual nodes
 will be briefly unavailable as they cycle.
 
 Cluster configuration changes (--allowed-ips, --restart-mode, --rebalance-strategy)
-and label changes take effect without a restart.`,
+and label changes take effect without a restart.
+
+Labels are merged with existing labels by default. Use 'key=value' to add or
+overwrite a label, and 'key-' (with a trailing dash) to remove one.`,
 				Args: util.ExactArgs(1, "a cluster ID"),
 			}
-			cmd.Flags().StringToString("label", nil, "Label to apply to the cluster ('key=value'), can be specified multiple times; replaces all existing labels")
+			cmd.Flags().StringArray("label", nil, "Label to set ('key=value') or remove ('key-'); merges with existing labels")
 			cmd.Flags().Uint32("replication-factor", 0, "Default replication factor for new collections")
 			cmd.Flags().Int32("write-consistency-factor", 0, "Default write consistency factor for new collections")
 			cmd.Flags().Bool("async-scorer", false, "Enable async scorer (uses io_uring on Linux)")
@@ -91,11 +93,12 @@ and label changes take effect without a restart.`,
 
 			// Labels
 			if cmd.Flags().Changed("label") {
-				labelMap, _ := cmd.Flags().GetStringToString("label")
-				updated.Labels = nil
-				for k, v := range labelMap {
-					updated.Labels = append(updated.Labels, &commonv1.KeyValue{Key: k, Value: v})
+				raw, _ := cmd.Flags().GetStringArray("label")
+				changes, err := util.ParseLabels(raw)
+				if err != nil {
+					return nil, err
 				}
+				updated.Labels = util.MergeLabels(updated.Labels, changes)
 			}
 
 			// Ensure configuration exists

--- a/internal/cmd/cluster/update_test.go
+++ b/internal/cmd/cluster/update_test.go
@@ -79,7 +79,7 @@ func TestUpdateCluster_ClearLabels(t *testing.T) {
 	assert.Empty(t, req.GetCluster().GetLabels())
 }
 
-func TestUpdateCluster_MergeLabels(t *testing.T) {
+func TestUpdateCluster_ApplyLabels(t *testing.T) {
 	env := testutil.NewTestEnv(t)
 
 	env.Server.GetClusterCalls.Always(func(_ context.Context, req *clusterv1.GetClusterRequest) (*clusterv1.GetClusterResponse, error) {

--- a/internal/cmd/cluster/update_test.go
+++ b/internal/cmd/cluster/update_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	clusterv1 "github.com/qdrant/qdrant-cloud-public-api/gen/go/qdrant/cloud/cluster/v1"
+	commonv1 "github.com/qdrant/qdrant-cloud-public-api/gen/go/qdrant/cloud/common/v1"
 
 	"github.com/qdrant/qcloud-cli/internal/testutil"
 )
@@ -50,7 +51,14 @@ func TestUpdateCluster_ClearLabels(t *testing.T) {
 
 	env.Server.GetClusterCalls.Always(func(_ context.Context, req *clusterv1.GetClusterRequest) (*clusterv1.GetClusterResponse, error) {
 		return &clusterv1.GetClusterResponse{
-			Cluster: &clusterv1.Cluster{Id: req.GetClusterId(), Name: "my-cluster"},
+			Cluster: &clusterv1.Cluster{
+				Id:   req.GetClusterId(),
+				Name: "my-cluster",
+				Labels: []*commonv1.KeyValue{
+					{Key: "env", Value: "staging"},
+					{Key: "team", Value: "infra"},
+				},
+			},
 		}, nil
 	})
 	env.Server.UpdateClusterCalls.Always(func(_ context.Context, req *clusterv1.UpdateClusterRequest) (*clusterv1.UpdateClusterResponse, error) {
@@ -59,12 +67,96 @@ func TestUpdateCluster_ClearLabels(t *testing.T) {
 		}, nil
 	})
 
-	_, _, err := testutil.Exec(t, env, "cluster", "update", "cluster-abc")
+	_, _, err := testutil.Exec(t, env,
+		"cluster", "update", "cluster-abc",
+		"--label", "env-",
+		"--label", "team-",
+	)
 	require.NoError(t, err)
 
 	req, ok := env.Server.UpdateClusterCalls.Last()
 	require.True(t, ok)
 	assert.Empty(t, req.GetCluster().GetLabels())
+}
+
+func TestUpdateCluster_MergeLabels(t *testing.T) {
+	env := testutil.NewTestEnv(t)
+
+	env.Server.GetClusterCalls.Always(func(_ context.Context, req *clusterv1.GetClusterRequest) (*clusterv1.GetClusterResponse, error) {
+		return &clusterv1.GetClusterResponse{
+			Cluster: &clusterv1.Cluster{
+				Id:   req.GetClusterId(),
+				Name: "my-cluster",
+				Labels: []*commonv1.KeyValue{
+					{Key: "env", Value: "staging"},
+					{Key: "team", Value: "infra"},
+				},
+			},
+		}, nil
+	})
+	env.Server.UpdateClusterCalls.Always(func(_ context.Context, req *clusterv1.UpdateClusterRequest) (*clusterv1.UpdateClusterResponse, error) {
+		return &clusterv1.UpdateClusterResponse{Cluster: req.GetCluster()}, nil
+	})
+
+	_, _, err := testutil.Exec(t, env,
+		"cluster", "update", "cluster-abc",
+		"--label", "env=prod",
+	)
+	require.NoError(t, err)
+
+	req, ok := env.Server.UpdateClusterCalls.Last()
+	require.True(t, ok)
+	capturedLabels := make(map[string]string)
+	for _, kv := range req.GetCluster().GetLabels() {
+		capturedLabels[kv.GetKey()] = kv.GetValue()
+	}
+	assert.Equal(t, map[string]string{"env": "prod", "team": "infra"}, capturedLabels)
+}
+
+func TestUpdateCluster_RemoveLabel(t *testing.T) {
+	env := testutil.NewTestEnv(t)
+
+	env.Server.GetClusterCalls.Always(func(_ context.Context, req *clusterv1.GetClusterRequest) (*clusterv1.GetClusterResponse, error) {
+		return &clusterv1.GetClusterResponse{
+			Cluster: &clusterv1.Cluster{
+				Id:   req.GetClusterId(),
+				Name: "my-cluster",
+				Labels: []*commonv1.KeyValue{
+					{Key: "env", Value: "staging"},
+					{Key: "team", Value: "infra"},
+				},
+			},
+		}, nil
+	})
+	env.Server.UpdateClusterCalls.Always(func(_ context.Context, req *clusterv1.UpdateClusterRequest) (*clusterv1.UpdateClusterResponse, error) {
+		return &clusterv1.UpdateClusterResponse{Cluster: req.GetCluster()}, nil
+	})
+
+	_, _, err := testutil.Exec(t, env,
+		"cluster", "update", "cluster-abc",
+		"--label", "team-",
+	)
+	require.NoError(t, err)
+
+	req, ok := env.Server.UpdateClusterCalls.Last()
+	require.True(t, ok)
+	capturedLabels := make(map[string]string)
+	for _, kv := range req.GetCluster().GetLabels() {
+		capturedLabels[kv.GetKey()] = kv.GetValue()
+	}
+	assert.Equal(t, map[string]string{"env": "staging"}, capturedLabels)
+}
+
+func TestUpdateCluster_InvalidLabelFormat(t *testing.T) {
+	env := testutil.NewTestEnv(t)
+	setupUpdateHandlers(env)
+
+	_, _, err := testutil.Exec(t, env,
+		"cluster", "update", "cluster-abc",
+		"--label", "badformat",
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid --label value")
 }
 
 func TestUpdateCluster_APIError(t *testing.T) {

--- a/internal/cmd/util/labels.go
+++ b/internal/cmd/util/labels.go
@@ -1,0 +1,92 @@
+package util
+
+import (
+	"fmt"
+	"maps"
+	"sort"
+	"strings"
+
+	commonv1 "github.com/qdrant/qdrant-cloud-public-api/gen/go/qdrant/cloud/common/v1"
+)
+
+// LabelChanges holds the parsed result of --label flags.
+type LabelChanges struct {
+	Set    map[string]string
+	Remove map[string]bool
+}
+
+// ParseLabels parses a slice of raw --label flag values into upserts and removals.
+//
+// Accepted forms:
+//   - "key=value" -- upsert (empty value is valid: "key=")
+//   - "key-"      -- remove the label with that key
+//
+// Returns an error for malformed entries like "key" (no = and no trailing -),
+// "=value" (empty key), or "" (empty string).
+//
+// When the same key appears multiple times, the last occurrence wins.
+func ParseLabels(raw []string) (*LabelChanges, error) {
+	changes := &LabelChanges{
+		Set:    make(map[string]string),
+		Remove: make(map[string]bool),
+	}
+
+	for _, entry := range raw {
+		if entry == "" {
+			return nil, fmt.Errorf("empty --label value")
+		}
+
+		if key, value, ok := strings.Cut(entry, "="); ok {
+			if key == "" {
+				return nil, fmt.Errorf("empty key in --label %q", entry)
+			}
+
+			// Last operation wins, hence if a label is set after it's removal, clean it from the Remove field.
+			delete(changes.Remove, key)
+			changes.Set[key] = value
+			continue
+		}
+
+		if strings.HasSuffix(entry, "-") {
+			key := entry[:len(entry)-1]
+			if key == "" {
+				return nil, fmt.Errorf("empty key in --label %q", entry)
+			}
+
+
+			// Last operation wins, hence if a label is set after it's set, clean it from the Set field.
+			delete(changes.Set, key)
+			changes.Remove[key] = true
+			continue
+		}
+
+		return nil, fmt.Errorf("invalid --label value %q: use 'key=value' to set or 'key-' to remove", entry)
+	}
+
+	return changes, nil
+}
+
+// ApplyLabels applies LabelChanges to an existing label set and returns a new
+// slice sorted by key. The input slice is not modified. Removing a key that
+// does not exist is a silent no-op.
+func ApplyLabels(existing []*commonv1.KeyValue, changes *LabelChanges) []*commonv1.KeyValue {
+	merged := make(map[string]string, len(existing))
+	for _, kv := range existing {
+		merged[kv.GetKey()] = kv.GetValue()
+	}
+
+	for key := range changes.Remove {
+		delete(merged, key)
+	}
+	maps.Copy(merged, changes.Set)
+
+	result := make([]*commonv1.KeyValue, 0, len(merged))
+	for k, v := range merged {
+		result = append(result, &commonv1.KeyValue{Key: k, Value: v})
+	}
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].GetKey() < result[j].GetKey()
+	})
+
+	return result
+}

--- a/internal/cmd/util/labels.go
+++ b/internal/cmd/util/labels.go
@@ -53,7 +53,6 @@ func ParseLabels(raw []string) (*LabelChanges, error) {
 				return nil, fmt.Errorf("empty key in --label %q", entry)
 			}
 
-
 			// Last operation wins, hence if a label is set after it's set, clean it from the Set field.
 			delete(changes.Set, key)
 			changes.Remove[key] = true

--- a/internal/cmd/util/labels_test.go
+++ b/internal/cmd/util/labels_test.go
@@ -1,0 +1,206 @@
+package util_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	commonv1 "github.com/qdrant/qdrant-cloud-public-api/gen/go/qdrant/cloud/common/v1"
+
+	"github.com/qdrant/qcloud-cli/internal/cmd/util"
+)
+
+func TestParseLabels(t *testing.T) {
+	tests := []struct {
+		name      string
+		raw       []string
+		wantSet   map[string]string
+		wantRm    []string
+		wantError string
+	}{
+		{
+			name:    "single set",
+			raw:     []string{"env=prod"},
+			wantSet: map[string]string{"env": "prod"},
+		},
+		{
+			name:    "empty value is valid",
+			raw:     []string{"env="},
+			wantSet: map[string]string{"env": ""},
+		},
+		{
+			name:    "value with equals sign",
+			raw:     []string{"a=b=c"},
+			wantSet: map[string]string{"a": "b=c"},
+		},
+		{
+			name:    "multiple sets",
+			raw:     []string{"env=prod", "team=platform"},
+			wantSet: map[string]string{"env": "prod", "team": "platform"},
+		},
+		{
+			name:   "single remove",
+			raw:    []string{"env-"},
+			wantRm: []string{"env"},
+		},
+		{
+			name:    "mixed set and remove",
+			raw:     []string{"env=prod", "old-"},
+			wantSet: map[string]string{"env": "prod"},
+			wantRm:  []string{"old"},
+		},
+		{
+			name:   "last wins: set then remove",
+			raw:    []string{"env=prod", "env-"},
+			wantRm: []string{"env"},
+		},
+		{
+			name:    "last wins: remove then set",
+			raw:     []string{"env-", "env=prod"},
+			wantSet: map[string]string{"env": "prod"},
+		},
+		{
+			name:    "key with prefix slash",
+			raw:     []string{"my.prefix/env=prod"},
+			wantSet: map[string]string{"my.prefix/env": "prod"},
+		},
+		{
+			name:      "no equals no dash",
+			raw:       []string{"badformat"},
+			wantError: "invalid --label value",
+		},
+		{
+			name:      "empty key with value",
+			raw:       []string{"=value"},
+			wantError: "empty key",
+		},
+		{
+			name:      "empty string",
+			raw:       []string{""},
+			wantError: "empty --label value",
+		},
+		{
+			name:      "bare dash",
+			raw:       []string{"-"},
+			wantError: "empty key",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			changes, err := util.ParseLabels(tt.raw)
+			if tt.wantError != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantError)
+				return
+			}
+			require.NoError(t, err)
+
+			if tt.wantSet != nil {
+				assert.Equal(t, tt.wantSet, changes.Set)
+			} else {
+				assert.Empty(t, changes.Set)
+			}
+
+			var gotRm []string
+			for k := range changes.Remove {
+				gotRm = append(gotRm, k)
+			}
+			if tt.wantRm != nil {
+				assert.ElementsMatch(t, tt.wantRm, gotRm)
+			} else {
+				assert.Empty(t, gotRm)
+			}
+		})
+	}
+}
+
+func TestApplyLabels(t *testing.T) {
+	tests := []struct {
+		name     string
+		existing []*commonv1.KeyValue
+		set      map[string]string
+		remove   []string
+		want     map[string]string
+	}{
+		{
+			name:     "upsert existing key",
+			existing: kvs("env", "staging", "team", "infra"),
+			set:      map[string]string{"env": "prod"},
+			want:     map[string]string{"env": "prod", "team": "infra"},
+		},
+		{
+			name:     "add new key",
+			existing: kvs("env", "staging"),
+			set:      map[string]string{"team": "platform"},
+			want:     map[string]string{"env": "staging", "team": "platform"},
+		},
+		{
+			name:     "remove existing key",
+			existing: kvs("env", "staging", "team", "infra"),
+			remove:   []string{"team"},
+			want:     map[string]string{"env": "staging"},
+		},
+		{
+			name:     "remove nonexistent key is silent",
+			existing: kvs("env", "staging"),
+			remove:   []string{"nonexistent"},
+			want:     map[string]string{"env": "staging"},
+		},
+		{
+			name:     "remove all keys",
+			existing: kvs("env", "staging", "team", "infra"),
+			remove:   []string{"env", "team"},
+			want:     map[string]string{},
+		},
+		{
+			name:     "add to empty",
+			existing: nil,
+			set:      map[string]string{"env": "prod"},
+			want:     map[string]string{"env": "prod"},
+		},
+		{
+			name:     "no changes",
+			existing: kvs("env", "staging"),
+			want:     map[string]string{"env": "staging"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			changes := &util.LabelChanges{
+				Set:    tt.set,
+				Remove: make(map[string]bool),
+			}
+			if changes.Set == nil {
+				changes.Set = make(map[string]string)
+			}
+			for _, k := range tt.remove {
+				changes.Remove[k] = true
+			}
+
+			result := util.ApplyLabels(tt.existing, changes)
+
+			got := make(map[string]string)
+			for _, kv := range result {
+				got[kv.GetKey()] = kv.GetValue()
+			}
+			assert.Equal(t, tt.want, got)
+
+			// Verify sorted by key
+			for i := 1; i < len(result); i++ {
+				assert.Less(t, result[i-1].GetKey(), result[i].GetKey(), "result should be sorted by key")
+			}
+		})
+	}
+}
+
+// kvs creates key-value pairs from alternating key, value strings.
+func kvs(pairs ...string) []*commonv1.KeyValue {
+	var result []*commonv1.KeyValue
+	for i := 0; i < len(pairs); i += 2 {
+		result = append(result, &commonv1.KeyValue{Key: pairs[i], Value: pairs[i+1]})
+	}
+	return result
+}


### PR DESCRIPTION
- Changes label behavior on `cluster update` from **replace-all** to **additive merge** by default. Labels specified with `--label key=value` are now upserted into the existing label set instead of replacing it entirely.
- Adds support for **removing individual labels** using a trailing dash convention (`--label key-`), following the same syntax as `kubectl label`.
- Updates `cluster create` to use the same label parsing for consistency.