### PR TITLE
feat: add dependabot and remove renovate tags

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up tools
         uses: jdx/mise-action@5228313ee0372e111a38da051671ca30fc5a96db # v3.6.3
         with:
-          version: 2026.3.8 # renovate: datasource=github-releases depName=jdx/mise
+          version: 2026.3.8
 
       - name: Run GoReleaser
         run: goreleaser release --clean --snapshot

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up tools
         uses: jdx/mise-action@5228313ee0372e111a38da051671ca30fc5a96db # v3.6.3
         with:
-          version: 2026.3.8 # renovate: datasource=github-releases depName=jdx/mise
+          version: 2026.3.8
 
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
@@ -38,7 +38,7 @@ jobs:
       - name: Set up tools
         uses: jdx/mise-action@5228313ee0372e111a38da051671ca30fc5a96db # v3.6.3
         with:
-          version: 2026.3.8 # renovate: datasource=github-releases depName=jdx/mise
+          version: 2026.3.8
 
       - name: Run tests
         run: go test -coverpkg=./internal/... -coverprofile=build/coverage.txt -v -race ./...
@@ -52,7 +52,7 @@ jobs:
       - name: Set up tools
         uses: jdx/mise-action@5228313ee0372e111a38da051671ca30fc5a96db # v3.6.3
         with:
-          version: 2026.3.8 # renovate: datasource=github-releases depName=jdx/mise
+          version: 2026.3.8
 
       - name: Run go mod tidy
         run: go mod tidy


### PR DESCRIPTION
Add dependabot configuration for gomod and github-actions ecosystems and remove leftover renovate inline comments from `ci.yml` and `build.yml` that appear to not be active.