### PR TITLE
feat: add cluster logs command

### DIFF
--- a/internal/cmd/cluster/cluster.go
+++ b/internal/cmd/cluster/cluster.go
@@ -26,6 +26,7 @@ func NewCommand(s *state.State) *cobra.Command {
 		newVersionCommand(s),
 		newKeyCommand(s),
 		newScaleCommand(s),
+		newLogsCommand(s),
 	)
 	return cmd
 }

--- a/internal/cmd/cluster/logs.go
+++ b/internal/cmd/cluster/logs.go
@@ -1,0 +1,104 @@
+package cluster
+
+import (
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/spf13/cobra"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	monitoringv1 "github.com/qdrant/qdrant-cloud-public-api/gen/go/qdrant/cloud/monitoring/v1"
+
+	"github.com/qdrant/qcloud-cli/internal/cmd/base"
+	"github.com/qdrant/qcloud-cli/internal/cmd/completion"
+	"github.com/qdrant/qcloud-cli/internal/cmd/output"
+	"github.com/qdrant/qcloud-cli/internal/cmd/util"
+	"github.com/qdrant/qcloud-cli/internal/state"
+)
+
+func newLogsCommand(s *state.State) *cobra.Command {
+	cmd := base.DescribeCmd[*monitoringv1.GetClusterLogsResponse]{
+		Use:   "logs <cluster-id>",
+		Short: "Retrieve logs for a cluster",
+		Args:  util.ExactArgs(1, "a cluster ID"),
+		Example: `# Get logs for a cluster
+qcloud cluster logs abc-123
+
+# Get logs since a specific date
+qcloud cluster logs abc-123 --since 2024-01-01
+
+# Get logs in a specific time range
+qcloud cluster logs abc-123 --since 2024-01-01T00:00:00Z --until 2024-01-02T00:00:00Z
+
+# Get logs in JSON format
+qcloud cluster logs abc-123 --json`,
+		Fetch: func(s *state.State, cmd *cobra.Command, args []string) (*monitoringv1.GetClusterLogsResponse, error) {
+			ctx := cmd.Context()
+			client, err := s.Client(ctx)
+			if err != nil {
+				return nil, err
+			}
+
+			accountID, err := s.AccountID()
+			if err != nil {
+				return nil, err
+			}
+
+			req := &monitoringv1.GetClusterLogsRequest{
+				AccountId: accountID,
+				ClusterId: args[0],
+			}
+
+			if cmd.Flags().Changed("since") {
+				sinceStr, _ := cmd.Flags().GetString("since")
+				t, err := parseLogTime(sinceStr)
+				if err != nil {
+					return nil, fmt.Errorf("invalid --since %q: must be RFC3339 or YYYY-MM-DD", sinceStr)
+				}
+				req.Since = timestamppb.New(t)
+			}
+
+			if cmd.Flags().Changed("until") {
+				untilStr, _ := cmd.Flags().GetString("until")
+				t, err := parseLogTime(untilStr)
+				if err != nil {
+					return nil, fmt.Errorf("invalid --until %q: must be RFC3339 or YYYY-MM-DD", untilStr)
+				}
+				req.Until = timestamppb.New(t)
+			}
+
+			resp, err := client.Monitoring().GetClusterLogs(ctx, req)
+			if err != nil {
+				return nil, fmt.Errorf("failed to get cluster logs: %w", err)
+			}
+			return resp, nil
+		},
+		PrintText: func(cmd *cobra.Command, w io.Writer, resp *monitoringv1.GetClusterLogsResponse) error {
+			timestamps, _ := cmd.Flags().GetBool("timestamps")
+			for _, entry := range resp.GetItems() {
+				if timestamps {
+					fmt.Fprintf(w, "%s  %s\n", output.FullDateTime(entry.GetTimestamp().AsTime()), entry.GetMessage())
+				} else {
+					fmt.Fprintln(w, entry.GetMessage())
+				}
+			}
+			return nil
+		},
+		ValidArgsFunction: completion.ClusterIDCompletion(s),
+	}.CobraCommand(s)
+
+	cmd.Flags().StringP("since", "s", "", "Start time for logs (RFC3339 or YYYY-MM-DD, default: 3 days ago)")
+	cmd.Flags().StringP("until", "u", "", "End time for logs (RFC3339 or YYYY-MM-DD, default: now)")
+	cmd.Flags().BoolP("timestamps", "t", false, "Prepend each log line with its timestamp")
+
+	return cmd
+}
+
+func parseLogTime(s string) (time.Time, error) {
+	t, err := time.Parse(time.RFC3339, s)
+	if err == nil {
+		return t, nil
+	}
+	return time.Parse("2006-01-02", s)
+}

--- a/internal/cmd/cluster/logs_test.go
+++ b/internal/cmd/cluster/logs_test.go
@@ -1,0 +1,220 @@
+package cluster_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	monitoringv1 "github.com/qdrant/qdrant-cloud-public-api/gen/go/qdrant/cloud/monitoring/v1"
+
+	"github.com/qdrant/qcloud-cli/internal/testutil"
+)
+
+func logEntry(ts time.Time, msg string) *monitoringv1.LogEntry {
+	return &monitoringv1.LogEntry{
+		Timestamp: timestamppb.New(ts),
+		Message:   msg,
+	}
+}
+
+func TestClusterLogs_TextOutput(t *testing.T) {
+	env := testutil.NewTestEnv(t)
+
+	env.MonitoringServer.GetClusterLogsCalls.Returns(&monitoringv1.GetClusterLogsResponse{
+		Items: []*monitoringv1.LogEntry{
+			logEntry(time.Now(), "Starting Qdrant server"),
+			logEntry(time.Now(), "Loaded 3 collections"),
+		},
+	}, nil)
+
+	stdout, _, err := testutil.Exec(t, env, "cluster", "logs", "my-cluster")
+	require.NoError(t, err)
+
+	assert.Contains(t, stdout, "Starting Qdrant server")
+	assert.Contains(t, stdout, "Loaded 3 collections")
+}
+
+func TestClusterLogs_NoTimestampByDefault(t *testing.T) {
+	env := testutil.NewTestEnv(t)
+
+	ts := time.Date(2024, 1, 15, 10, 23, 45, 0, time.UTC)
+	env.MonitoringServer.GetClusterLogsCalls.Returns(&monitoringv1.GetClusterLogsResponse{
+		Items: []*monitoringv1.LogEntry{
+			logEntry(ts, "some message"),
+		},
+	}, nil)
+
+	stdout, _, err := testutil.Exec(t, env, "cluster", "logs", "my-cluster")
+	require.NoError(t, err)
+
+	assert.Contains(t, stdout, "some message")
+	assert.NotContains(t, stdout, "2024-01-15")
+}
+
+func TestClusterLogs_TimestampsFlag(t *testing.T) {
+	env := testutil.NewTestEnv(t)
+
+	ts := time.Date(2024, 1, 15, 10, 23, 45, 0, time.UTC)
+	env.MonitoringServer.GetClusterLogsCalls.Returns(&monitoringv1.GetClusterLogsResponse{
+		Items: []*monitoringv1.LogEntry{
+			logEntry(ts, "some message"),
+		},
+	}, nil)
+
+	stdout, _, err := testutil.Exec(t, env, "cluster", "logs", "my-cluster", "--timestamps")
+	require.NoError(t, err)
+
+	assert.Contains(t, stdout, "2024-01-15 10:23:45 UTC")
+	assert.Contains(t, stdout, "some message")
+}
+
+func TestClusterLogs_TimestampsShorthand(t *testing.T) {
+	env := testutil.NewTestEnv(t)
+
+	ts := time.Date(2024, 6, 1, 0, 0, 0, 0, time.UTC)
+	env.MonitoringServer.GetClusterLogsCalls.Returns(&monitoringv1.GetClusterLogsResponse{
+		Items: []*monitoringv1.LogEntry{
+			logEntry(ts, "shorthand check"),
+		},
+	}, nil)
+
+	stdout, _, err := testutil.Exec(t, env, "cluster", "logs", "my-cluster", "-t")
+	require.NoError(t, err)
+
+	assert.Contains(t, stdout, "2024-06-01")
+	assert.Contains(t, stdout, "shorthand check")
+}
+
+func TestClusterLogs_JSONOutput(t *testing.T) {
+	env := testutil.NewTestEnv(t)
+
+	env.MonitoringServer.GetClusterLogsCalls.Returns(&monitoringv1.GetClusterLogsResponse{
+		Items: []*monitoringv1.LogEntry{
+			logEntry(time.Now(), "json log line"),
+		},
+	}, nil)
+
+	stdout, _, err := testutil.Exec(t, env, "cluster", "logs", "my-cluster", "--json")
+	require.NoError(t, err)
+
+	assert.Contains(t, stdout, `"items"`)
+	assert.Contains(t, stdout, `"message"`)
+	assert.Contains(t, stdout, "json log line")
+}
+
+func TestClusterLogs_EmptyResponse(t *testing.T) {
+	env := testutil.NewTestEnv(t)
+
+	env.MonitoringServer.GetClusterLogsCalls.Returns(&monitoringv1.GetClusterLogsResponse{}, nil)
+
+	stdout, _, err := testutil.Exec(t, env, "cluster", "logs", "my-cluster")
+	require.NoError(t, err)
+
+	assert.Empty(t, stdout)
+}
+
+func TestClusterLogs_AccountIDPassedToServer(t *testing.T) {
+	env := testutil.NewTestEnv(t)
+
+	env.MonitoringServer.GetClusterLogsCalls.Returns(&monitoringv1.GetClusterLogsResponse{}, nil)
+
+	_, _, err := testutil.Exec(t, env, "cluster", "logs", "my-cluster")
+	require.NoError(t, err)
+
+	req, ok := env.MonitoringServer.GetClusterLogsCalls.Last()
+	require.True(t, ok)
+	assert.Equal(t, "test-account-id", req.GetAccountId())
+}
+
+func TestClusterLogs_ClusterIDPassedToServer(t *testing.T) {
+	env := testutil.NewTestEnv(t)
+
+	env.MonitoringServer.GetClusterLogsCalls.Returns(&monitoringv1.GetClusterLogsResponse{}, nil)
+
+	_, _, err := testutil.Exec(t, env, "cluster", "logs", "target-cluster")
+	require.NoError(t, err)
+
+	req, ok := env.MonitoringServer.GetClusterLogsCalls.Last()
+	require.True(t, ok)
+	assert.Equal(t, "target-cluster", req.GetClusterId())
+}
+
+func TestClusterLogs_SinceFlag_RFC3339(t *testing.T) {
+	env := testutil.NewTestEnv(t)
+
+	env.MonitoringServer.GetClusterLogsCalls.Returns(&monitoringv1.GetClusterLogsResponse{}, nil)
+
+	_, _, err := testutil.Exec(t, env, "cluster", "logs", "my-cluster", "--since", "2024-01-01T00:00:00Z")
+	require.NoError(t, err)
+
+	req, ok := env.MonitoringServer.GetClusterLogsCalls.Last()
+	require.True(t, ok)
+	require.NotNil(t, req.GetSince())
+	assert.Equal(t, time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC), req.GetSince().AsTime())
+}
+
+func TestClusterLogs_SinceFlag_DateOnly(t *testing.T) {
+	env := testutil.NewTestEnv(t)
+
+	env.MonitoringServer.GetClusterLogsCalls.Returns(&monitoringv1.GetClusterLogsResponse{}, nil)
+
+	_, _, err := testutil.Exec(t, env, "cluster", "logs", "my-cluster", "-s", "2024-03-15")
+	require.NoError(t, err)
+
+	req, ok := env.MonitoringServer.GetClusterLogsCalls.Last()
+	require.True(t, ok)
+	require.NotNil(t, req.GetSince())
+	assert.Equal(t, time.Date(2024, 3, 15, 0, 0, 0, 0, time.UTC), req.GetSince().AsTime())
+}
+
+func TestClusterLogs_UntilFlag(t *testing.T) {
+	env := testutil.NewTestEnv(t)
+
+	env.MonitoringServer.GetClusterLogsCalls.Returns(&monitoringv1.GetClusterLogsResponse{}, nil)
+
+	_, _, err := testutil.Exec(t, env, "cluster", "logs", "my-cluster", "-u", "2024-02-01T12:00:00Z")
+	require.NoError(t, err)
+
+	req, ok := env.MonitoringServer.GetClusterLogsCalls.Last()
+	require.True(t, ok)
+	require.NotNil(t, req.GetUntil())
+	assert.Equal(t, time.Date(2024, 2, 1, 12, 0, 0, 0, time.UTC), req.GetUntil().AsTime())
+}
+
+func TestClusterLogs_NoSinceByDefault(t *testing.T) {
+	env := testutil.NewTestEnv(t)
+
+	env.MonitoringServer.GetClusterLogsCalls.Returns(&monitoringv1.GetClusterLogsResponse{}, nil)
+
+	_, _, err := testutil.Exec(t, env, "cluster", "logs", "my-cluster")
+	require.NoError(t, err)
+
+	req, ok := env.MonitoringServer.GetClusterLogsCalls.Last()
+	require.True(t, ok)
+	assert.Nil(t, req.GetSince())
+	assert.Nil(t, req.GetUntil())
+}
+
+func TestClusterLogs_InvalidSince(t *testing.T) {
+	env := testutil.NewTestEnv(t)
+
+	_, _, err := testutil.Exec(t, env, "cluster", "logs", "my-cluster", "--since", "not-a-date")
+	require.Error(t, err)
+}
+
+func TestClusterLogs_InvalidUntil(t *testing.T) {
+	env := testutil.NewTestEnv(t)
+
+	_, _, err := testutil.Exec(t, env, "cluster", "logs", "my-cluster", "--until", "not-a-date")
+	require.Error(t, err)
+}
+
+func TestClusterLogs_MissingArg(t *testing.T) {
+	env := testutil.NewTestEnv(t)
+
+	_, _, err := testutil.Exec(t, env, "cluster", "logs")
+	require.Error(t, err)
+}

--- a/internal/qcloudapi/client.go
+++ b/internal/qcloudapi/client.go
@@ -12,6 +12,7 @@ import (
 	backupv1 "github.com/qdrant/qdrant-cloud-public-api/gen/go/qdrant/cloud/cluster/backup/v1"
 	clusterv1 "github.com/qdrant/qdrant-cloud-public-api/gen/go/qdrant/cloud/cluster/v1"
 	hybridv1 "github.com/qdrant/qdrant-cloud-public-api/gen/go/qdrant/cloud/hybrid/v1"
+	monitoringv1 "github.com/qdrant/qdrant-cloud-public-api/gen/go/qdrant/cloud/monitoring/v1"
 	platformv1 "github.com/qdrant/qdrant-cloud-public-api/gen/go/qdrant/cloud/platform/v1"
 )
 
@@ -24,6 +25,7 @@ type Client struct {
 	databaseApiKey clusterauthv2.DatabaseApiKeyServiceClient
 	backup         backupv1.BackupServiceClient
 	hybrid         hybridv1.HybridCloudServiceClient
+	monitoring     monitoringv1.MonitoringServiceClient
 }
 
 // New creates a new gRPC client connected to the given endpoint with the given API key.
@@ -54,6 +56,7 @@ func newFromConn(conn *grpc.ClientConn) *Client {
 		databaseApiKey: clusterauthv2.NewDatabaseApiKeyServiceClient(conn),
 		backup:         backupv1.NewBackupServiceClient(conn),
 		hybrid:         hybridv1.NewHybridCloudServiceClient(conn),
+		monitoring:     monitoringv1.NewMonitoringServiceClient(conn),
 	}
 }
 
@@ -85,6 +88,11 @@ func (c *Client) Backup() backupv1.BackupServiceClient {
 // Hybrid returns the HybridCloudService gRPC client.
 func (c *Client) Hybrid() hybridv1.HybridCloudServiceClient {
 	return c.hybrid
+}
+
+// Monitoring returns the MonitoringService gRPC client.
+func (c *Client) Monitoring() monitoringv1.MonitoringServiceClient {
+	return c.monitoring
 }
 
 // Close closes the underlying gRPC connection.

--- a/internal/testutil/fake_monitoring.go
+++ b/internal/testutil/fake_monitoring.go
@@ -1,0 +1,21 @@
+package testutil
+
+import (
+	"context"
+
+	monitoringv1 "github.com/qdrant/qdrant-cloud-public-api/gen/go/qdrant/cloud/monitoring/v1"
+)
+
+// FakeMonitoringService is a test fake that implements MonitoringServiceServer.
+// Use the *Calls fields to configure responses and inspect captured requests.
+type FakeMonitoringService struct {
+	monitoringv1.UnimplementedMonitoringServiceServer
+
+	GetClusterLogsCalls MethodSpy[*monitoringv1.GetClusterLogsRequest, *monitoringv1.GetClusterLogsResponse]
+}
+
+// GetClusterLogs records the call and dispatches via GetClusterLogsCalls.
+func (f *FakeMonitoringService) GetClusterLogs(ctx context.Context, req *monitoringv1.GetClusterLogsRequest) (*monitoringv1.GetClusterLogsResponse, error) {
+	f.GetClusterLogsCalls.record(req)
+	return f.GetClusterLogsCalls.dispatch(ctx, req, f.UnimplementedMonitoringServiceServer.GetClusterLogs)
+}

--- a/internal/testutil/server.go
+++ b/internal/testutil/server.go
@@ -16,6 +16,7 @@ import (
 	backupv1 "github.com/qdrant/qdrant-cloud-public-api/gen/go/qdrant/cloud/cluster/backup/v1"
 	clusterv1 "github.com/qdrant/qdrant-cloud-public-api/gen/go/qdrant/cloud/cluster/v1"
 	hybridv1 "github.com/qdrant/qdrant-cloud-public-api/gen/go/qdrant/cloud/hybrid/v1"
+	monitoringv1 "github.com/qdrant/qdrant-cloud-public-api/gen/go/qdrant/cloud/monitoring/v1"
 	platformv1 "github.com/qdrant/qdrant-cloud-public-api/gen/go/qdrant/cloud/platform/v1"
 
 	"github.com/qdrant/qcloud-cli/internal/qcloudapi"
@@ -59,6 +60,7 @@ type TestEnv struct {
 	DatabaseApiKeyServer *FakeDatabaseApiKeyService
 	BackupServer         *FakeBackupService
 	HybridServer         *FakeHybridService
+	MonitoringServer     *FakeMonitoringService
 	Capture              *RequestCapture
 	Cleanup              func()
 }
@@ -96,12 +98,19 @@ func WithVersion(v string) Option {
 func newBaseTestEnv(t *testing.T, cfg *envConfig) *TestEnv {
 	t.Helper()
 
+	// Redirect HOME to an empty temp dir so Config.Load never reads the real
+	// ~/.config/qcloud/config.yaml. Also clear QDRANT_CLOUD_CONFIG in case it
+	// is set in the caller's environment.
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("QDRANT_CLOUD_CONFIG", "")
+
 	fake := &FakeClusterService{}
 	fakeBooking := &FakeBookingService{}
 	fakePlatform := &FakePlatformService{}
 	fakeDatabaseApiKey := &FakeDatabaseApiKeyService{}
 	fakeBackup := &FakeBackupService{}
 	fakeHybrid := &FakeHybridService{}
+	fakeMonitoring := &FakeMonitoringService{}
 	capture := &RequestCapture{}
 
 	// Start gRPC server on bufconn.
@@ -113,6 +122,7 @@ func newBaseTestEnv(t *testing.T, cfg *envConfig) *TestEnv {
 	clusterauthv2.RegisterDatabaseApiKeyServiceServer(srv, fakeDatabaseApiKey)
 	backupv1.RegisterBackupServiceServer(srv, fakeBackup)
 	hybridv1.RegisterHybridCloudServiceServer(srv, fakeHybrid)
+	monitoringv1.RegisterMonitoringServiceServer(srv, fakeMonitoring)
 
 	go func() {
 		_ = srv.Serve(lis)
@@ -162,6 +172,7 @@ func newBaseTestEnv(t *testing.T, cfg *envConfig) *TestEnv {
 		DatabaseApiKeyServer: fakeDatabaseApiKey,
 		BackupServer:         fakeBackup,
 		HybridServer:         fakeHybrid,
+		MonitoringServer:     fakeMonitoring,
 		Capture:              capture,
 		Cleanup:              cleanup,
 	}


### PR DESCRIPTION
## Add `cluster logs` command

Adds a new `qcloud cluster logs <cluster-id>` subcommand that retrieves log entries for a cluster via the Monitoring gRPC service.

### Usage

```
qcloud cluster logs <cluster-id> [flags]

Flags:
  -s, --since string   Start time for logs (RFC3339 or YYYY-MM-DD, default: 3 days ago)
  -u, --until string   End time for logs (RFC3339 or YYYY-MM-DD, default: now)
  -t, --timestamps     Prepend each log line with its timestamp
      --json           Output as JSON
```

### Details

- Time filters accept both RFC3339 (`2024-01-01T00:00:00Z`) and date-only (`2024-01-01`) formats. When omitted, the server applies its own defaults.
- The `--timestamps` flag prepends each line with a human-readable UTC timestamp; without it only the raw log message is printed.
- `--json` outputs the full response proto, consistent with other commands.
- Cluster ID shell completion is wired up via the existing completion helper.
