### PR TITLE
feat: add account and account member commands

### DIFF
--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/qdrant/qcloud-cli/internal/cmd/account"
 	"github.com/qdrant/qcloud-cli/internal/cmd/backup"
 	"github.com/qdrant/qcloud-cli/internal/cmd/cloudprovider"
 	"github.com/qdrant/qcloud-cli/internal/cmd/cloudregion"
@@ -65,6 +66,7 @@ Documentation: https://github.com/qdrant/qcloud-cli`,
 	s.Config.BindPFlag(config.KeyAccountID, cmd.PersistentFlags().Lookup("account-id"))
 	s.Config.BindPFlag(config.KeyEndpoint, cmd.PersistentFlags().Lookup("endpoint"))
 
+	cmd.AddCommand(account.NewCommand(s))
 	cmd.AddCommand(version.NewCommand(s))
 	cmd.AddCommand(iam.NewCommand(s))
 	cmd.AddCommand(cluster.NewCommand(s))

--- a/internal/cmd/account/account.go
+++ b/internal/cmd/account/account.go
@@ -1,0 +1,28 @@
+package account
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/qdrant/qcloud-cli/internal/state"
+)
+
+// NewCommand creates the account command group.
+func NewCommand(s *state.State) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "account",
+		Short: "Manage Qdrant Cloud accounts",
+		Long: `Manage Qdrant Cloud accounts and their members.
+
+Use these commands to list, inspect, and update accounts that the current
+management key has access to. Account member commands show who belongs to the
+current account and whether they are the owner.`,
+		Args: cobra.NoArgs,
+	}
+	cmd.AddCommand(
+		newListCommand(s),
+		newDescribeCommand(s),
+		newUpdateCommand(s),
+		newMemberCommand(s),
+	)
+	return cmd
+}

--- a/internal/cmd/account/describe.go
+++ b/internal/cmd/account/describe.go
@@ -1,0 +1,89 @@
+package account
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	accountv1 "github.com/qdrant/qdrant-cloud-public-api/gen/go/qdrant/cloud/account/v1"
+
+	"github.com/qdrant/qcloud-cli/internal/cmd/base"
+	"github.com/qdrant/qcloud-cli/internal/cmd/completion"
+	"github.com/qdrant/qcloud-cli/internal/cmd/output"
+	"github.com/qdrant/qcloud-cli/internal/state"
+)
+
+func newDescribeCommand(s *state.State) *cobra.Command {
+	return base.DescribeCmd[*accountv1.Account]{
+		Use:   "describe [account-id]",
+		Short: "Describe an account",
+		Long: `Describe an account by its ID.
+
+If no account ID is provided, the current account (from --account-id, the
+active context, or the QDRANT_CLOUD_ACCOUNT_ID environment variable) is used.`,
+		Example: `# Describe the current account
+qcloud account describe
+
+# Describe a specific account
+qcloud account describe a1b2c3d4-e5f6-7890-abcd-ef1234567890
+
+# Output as JSON
+qcloud account describe --json`,
+		Args: cobra.MaximumNArgs(1),
+		Fetch: func(s *state.State, cmd *cobra.Command, args []string) (*accountv1.Account, error) {
+			ctx := cmd.Context()
+			client, err := s.Client(ctx)
+			if err != nil {
+				return nil, err
+			}
+
+			accountID, err := resolveAccountID(s, args)
+			if err != nil {
+				return nil, err
+			}
+
+			resp, err := client.Account().GetAccount(ctx, &accountv1.GetAccountRequest{
+				AccountId: accountID,
+			})
+			if err != nil {
+				return nil, fmt.Errorf("failed to get account: %w", err)
+			}
+
+			return resp.GetAccount(), nil
+		},
+		PrintText: func(_ *cobra.Command, w io.Writer, acct *accountv1.Account) error {
+			fmt.Fprintf(w, "ID:          %s\n", acct.GetId())
+			fmt.Fprintf(w, "Name:        %s\n", acct.GetName())
+			fmt.Fprintf(w, "Owner Email: %s\n", acct.GetOwnerEmail())
+			if company := acct.GetCompany(); company != nil {
+				fmt.Fprintf(w, "Company:     %s\n", company.GetName())
+				if company.Domain != nil {
+					fmt.Fprintf(w, "Domain:      %s\n", company.GetDomain())
+				}
+			}
+			if privs := acct.GetPrivileges(); len(privs) > 0 {
+				fmt.Fprintf(w, "Privileges:  %s\n", strings.Join(privs, ", "))
+			}
+			if acct.GetCreatedAt() != nil {
+				t := acct.GetCreatedAt().AsTime()
+				fmt.Fprintf(w, "Created:     %s  (%s)\n", output.HumanTime(t), output.FullDateTime(t))
+			}
+			if acct.GetLastModifiedAt() != nil {
+				t := acct.GetLastModifiedAt().AsTime()
+				fmt.Fprintf(w, "Modified:    %s  (%s)\n", output.HumanTime(t), output.FullDateTime(t))
+			}
+			return nil
+		},
+		ValidArgsFunction: completion.AccountIDCompletion(s),
+	}.CobraCommand(s)
+}
+
+// resolveAccountID returns args[0] if present, otherwise falls back to s.AccountID().
+func resolveAccountID(s *state.State, args []string) (string, error) {
+	if len(args) > 0 {
+		return args[0], nil
+	}
+	return s.AccountID()
+}

--- a/internal/cmd/account/describe_test.go
+++ b/internal/cmd/account/describe_test.go
@@ -1,0 +1,108 @@
+package account_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	accountv1 "github.com/qdrant/qdrant-cloud-public-api/gen/go/qdrant/cloud/account/v1"
+
+	"github.com/qdrant/qcloud-cli/internal/testutil"
+)
+
+func TestAccountDescribe_TableOutput(t *testing.T) {
+	env := testutil.NewTestEnv(t)
+
+	now := time.Now()
+	env.AccountServer.GetAccountCalls.Returns(&accountv1.GetAccountResponse{
+		Account: &accountv1.Account{
+			Id:         "acct-001",
+			Name:       "Production",
+			OwnerEmail: "owner@example.com",
+			Company: &accountv1.Company{
+				Name:   "Acme Corp",
+				Domain: new("acme.com"),
+			},
+			Privileges: []string{"premium"},
+			CreatedAt:  timestamppb.New(now.Add(-48 * time.Hour)),
+		},
+	}, nil)
+
+	stdout, _, err := testutil.Exec(t, env, "account", "describe", "acct-001")
+	require.NoError(t, err)
+	assert.Contains(t, stdout, "acct-001")
+	assert.Contains(t, stdout, "Production")
+	assert.Contains(t, stdout, "owner@example.com")
+	assert.Contains(t, stdout, "Acme Corp")
+	assert.Contains(t, stdout, "acme.com")
+	assert.Contains(t, stdout, "premium")
+
+	req, ok := env.AccountServer.GetAccountCalls.Last()
+	require.True(t, ok)
+	assert.Equal(t, "acct-001", req.GetAccountId())
+}
+
+func TestAccountDescribe_DefaultsToCurrentAccount(t *testing.T) {
+	env := testutil.NewTestEnv(t, testutil.WithAccountID("default-acct"))
+
+	env.AccountServer.GetAccountCalls.Returns(&accountv1.GetAccountResponse{
+		Account: &accountv1.Account{
+			Id:   "default-acct",
+			Name: "Default",
+		},
+	}, nil)
+
+	stdout, _, err := testutil.Exec(t, env, "account", "describe")
+	require.NoError(t, err)
+	assert.Contains(t, stdout, "default-acct")
+
+	req, ok := env.AccountServer.GetAccountCalls.Last()
+	require.True(t, ok)
+	assert.Equal(t, "default-acct", req.GetAccountId())
+}
+
+func TestAccountDescribe_JSONOutput(t *testing.T) {
+	env := testutil.NewTestEnv(t)
+
+	env.AccountServer.GetAccountCalls.Returns(&accountv1.GetAccountResponse{
+		Account: &accountv1.Account{
+			Id:         "acct-json",
+			Name:       "JSON Account",
+			OwnerEmail: "json@example.com",
+		},
+	}, nil)
+
+	stdout, _, err := testutil.Exec(t, env, "account", "describe", "acct-json", "--json")
+	require.NoError(t, err)
+
+	var result struct {
+		ID         string `json:"id"`
+		Name       string `json:"name"`
+		OwnerEmail string `json:"ownerEmail"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(stdout), &result))
+	assert.Equal(t, "acct-json", result.ID)
+	assert.Equal(t, "JSON Account", result.Name)
+	assert.Equal(t, "json@example.com", result.OwnerEmail)
+}
+
+func TestAccountDescribe_BackendError(t *testing.T) {
+	env := testutil.NewTestEnv(t)
+
+	env.AccountServer.GetAccountCalls.Returns(nil, fmt.Errorf("not found"))
+
+	_, _, err := testutil.Exec(t, env, "account", "describe", "acct-bad")
+	require.Error(t, err)
+}
+
+func TestAccountDescribe_TooManyArgs(t *testing.T) {
+	env := testutil.NewTestEnv(t)
+
+	_, _, err := testutil.Exec(t, env, "account", "describe", "arg1", "arg2")
+	require.Error(t, err)
+}

--- a/internal/cmd/account/list.go
+++ b/internal/cmd/account/list.go
@@ -1,0 +1,52 @@
+package account
+
+import (
+	"io"
+
+	"github.com/spf13/cobra"
+
+	accountv1 "github.com/qdrant/qdrant-cloud-public-api/gen/go/qdrant/cloud/account/v1"
+
+	"github.com/qdrant/qcloud-cli/internal/cmd/base"
+	"github.com/qdrant/qcloud-cli/internal/cmd/output"
+	"github.com/qdrant/qcloud-cli/internal/state"
+)
+
+func newListCommand(s *state.State) *cobra.Command {
+	return base.ListCmd[*accountv1.ListAccountsResponse]{
+		Use:   "list",
+		Short: "List accounts",
+		Long: `List all accounts associated with the authenticated management key.
+
+Returns every account the current API key has access to. No account ID is
+required because the server resolves accounts from the caller's credentials.`,
+		Example: `# List all accessible accounts
+qcloud account list
+
+# Output as JSON
+qcloud account list --json`,
+		Fetch: func(s *state.State, cmd *cobra.Command) (*accountv1.ListAccountsResponse, error) {
+			ctx := cmd.Context()
+			client, err := s.Client(ctx)
+			if err != nil {
+				return nil, err
+			}
+
+			return client.Account().ListAccounts(ctx, &accountv1.ListAccountsRequest{})
+		},
+		PrintText: func(_ *cobra.Command, w io.Writer, resp *accountv1.ListAccountsResponse) error {
+			t := output.NewTable[*accountv1.Account](w)
+			t.AddField("ID", func(v *accountv1.Account) string { return v.GetId() })
+			t.AddField("NAME", func(v *accountv1.Account) string { return v.GetName() })
+			t.AddField("OWNER EMAIL", func(v *accountv1.Account) string { return v.GetOwnerEmail() })
+			t.AddField("CREATED", func(v *accountv1.Account) string {
+				if v.GetCreatedAt() != nil {
+					return output.HumanTime(v.GetCreatedAt().AsTime())
+				}
+				return ""
+			})
+			t.Write(resp.GetItems())
+			return nil
+		},
+	}.CobraCommand(s)
+}

--- a/internal/cmd/account/list_test.go
+++ b/internal/cmd/account/list_test.go
@@ -1,0 +1,86 @@
+package account_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	accountv1 "github.com/qdrant/qdrant-cloud-public-api/gen/go/qdrant/cloud/account/v1"
+
+	"github.com/qdrant/qcloud-cli/internal/testutil"
+)
+
+func TestAccountList_TableOutput(t *testing.T) {
+	env := testutil.NewTestEnv(t)
+
+	env.AccountServer.ListAccountsCalls.Returns(&accountv1.ListAccountsResponse{
+		Items: []*accountv1.Account{
+			{
+				Id:         "acct-001",
+				Name:       "Production",
+				OwnerEmail: "owner@example.com",
+				CreatedAt:  timestamppb.New(time.Now().Add(-24 * time.Hour)),
+			},
+		},
+	}, nil)
+
+	stdout, _, err := testutil.Exec(t, env, "account", "list")
+	require.NoError(t, err)
+	assert.Contains(t, stdout, "ID")
+	assert.Contains(t, stdout, "NAME")
+	assert.Contains(t, stdout, "OWNER EMAIL")
+	assert.Contains(t, stdout, "CREATED")
+	assert.Contains(t, stdout, "acct-001")
+	assert.Contains(t, stdout, "Production")
+	assert.Contains(t, stdout, "owner@example.com")
+	assert.Contains(t, stdout, "ago")
+}
+
+func TestAccountList_JSONOutput(t *testing.T) {
+	env := testutil.NewTestEnv(t)
+
+	env.AccountServer.ListAccountsCalls.Returns(&accountv1.ListAccountsResponse{
+		Items: []*accountv1.Account{
+			{Id: "acct-json", Name: "Test Account"},
+		},
+	}, nil)
+
+	stdout, _, err := testutil.Exec(t, env, "account", "list", "--json")
+	require.NoError(t, err)
+
+	var result struct {
+		Items []struct {
+			ID   string `json:"id"`
+			Name string `json:"name"`
+		} `json:"items"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(stdout), &result))
+	require.Len(t, result.Items, 1)
+	assert.Equal(t, "acct-json", result.Items[0].ID)
+	assert.Equal(t, "Test Account", result.Items[0].Name)
+}
+
+func TestAccountList_BackendError(t *testing.T) {
+	env := testutil.NewTestEnv(t)
+
+	env.AccountServer.ListAccountsCalls.Returns(nil, fmt.Errorf("service unavailable"))
+
+	_, _, err := testutil.Exec(t, env, "account", "list")
+	require.Error(t, err)
+}
+
+func TestAccountList_Empty(t *testing.T) {
+	env := testutil.NewTestEnv(t)
+
+	env.AccountServer.ListAccountsCalls.Returns(&accountv1.ListAccountsResponse{}, nil)
+
+	stdout, _, err := testutil.Exec(t, env, "account", "list")
+	require.NoError(t, err)
+	assert.Contains(t, stdout, "ID")
+	assert.Contains(t, stdout, "NAME")
+}

--- a/internal/cmd/account/member.go
+++ b/internal/cmd/account/member.go
@@ -1,0 +1,25 @@
+package account
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/qdrant/qcloud-cli/internal/state"
+)
+
+func newMemberCommand(s *state.State) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "member",
+		Short: "Manage account members",
+		Long: `Manage members of the current Qdrant Cloud account.
+
+Members are users who have been added to the account. Each member has an
+associated user record and an ownership flag indicating whether they are the
+account owner.`,
+		Args: cobra.NoArgs,
+	}
+	cmd.AddCommand(
+		newMemberListCommand(s),
+		newMemberDescribeCommand(s),
+	)
+	return cmd
+}

--- a/internal/cmd/account/member_describe.go
+++ b/internal/cmd/account/member_describe.go
@@ -1,0 +1,66 @@
+package account
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	accountv1 "github.com/qdrant/qdrant-cloud-public-api/gen/go/qdrant/cloud/account/v1"
+
+	"github.com/qdrant/qcloud-cli/internal/cmd/base"
+	"github.com/qdrant/qcloud-cli/internal/cmd/completion"
+	"github.com/qdrant/qcloud-cli/internal/cmd/output"
+	"github.com/qdrant/qcloud-cli/internal/cmd/util"
+	"github.com/qdrant/qcloud-cli/internal/state"
+)
+
+func newMemberDescribeCommand(s *state.State) *cobra.Command {
+	return base.DescribeCmd[*accountv1.AccountMember]{
+		Use:   "describe <user-id>",
+		Short: "Describe an account member",
+		Long: `Describe a member of the current account by their user ID.
+
+Shows the member's user details and whether they are the account owner.`,
+		Example: `# Describe a member
+qcloud account member describe a1b2c3d4-e5f6-7890-abcd-ef1234567890
+
+# Output as JSON
+qcloud account member describe a1b2c3d4-e5f6-7890-abcd-ef1234567890 --json`,
+		Args: util.ExactArgs(1, "a user ID"),
+		Fetch: func(s *state.State, cmd *cobra.Command, args []string) (*accountv1.AccountMember, error) {
+			ctx := cmd.Context()
+			client, err := s.Client(ctx)
+			if err != nil {
+				return nil, err
+			}
+
+			accountID, err := s.AccountID()
+			if err != nil {
+				return nil, err
+			}
+
+			resp, err := client.Account().GetAccountMember(ctx, &accountv1.GetAccountMemberRequest{
+				AccountId: accountID,
+				UserId:    args[0],
+			})
+			if err != nil {
+				return nil, fmt.Errorf("failed to get account member: %w", err)
+			}
+
+			return resp.GetAccountMember(), nil
+		},
+		PrintText: func(_ *cobra.Command, w io.Writer, member *accountv1.AccountMember) error {
+			user := member.GetAccountMember()
+			fmt.Fprintf(w, "ID:      %s\n", user.GetId())
+			fmt.Fprintf(w, "Email:   %s\n", user.GetEmail())
+			fmt.Fprintf(w, "Owner:   %s\n", output.BoolYesNo(member.GetIsOwner()))
+			if user.GetCreatedAt() != nil {
+				t := user.GetCreatedAt().AsTime()
+				fmt.Fprintf(w, "Created: %s  (%s)\n", output.HumanTime(t), output.FullDateTime(t))
+			}
+			return nil
+		},
+		ValidArgsFunction: completion.AccountMemberIDCompletion(s),
+	}.CobraCommand(s)
+}

--- a/internal/cmd/account/member_describe_test.go
+++ b/internal/cmd/account/member_describe_test.go
@@ -1,0 +1,103 @@
+package account_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	accountv1 "github.com/qdrant/qdrant-cloud-public-api/gen/go/qdrant/cloud/account/v1"
+	iamv1 "github.com/qdrant/qdrant-cloud-public-api/gen/go/qdrant/cloud/iam/v1"
+
+	"github.com/qdrant/qcloud-cli/internal/testutil"
+)
+
+func TestMemberDescribe_TableOutput(t *testing.T) {
+	env := testutil.NewTestEnv(t, testutil.WithAccountID("test-account-id"))
+
+	env.AccountServer.GetAccountMemberCalls.Returns(&accountv1.GetAccountMemberResponse{
+		AccountMember: &accountv1.AccountMember{
+			AccountMember: &iamv1.User{
+				Id:        "user-001",
+				Email:     "owner@example.com",
+				CreatedAt: timestamppb.New(time.Now().Add(-48 * time.Hour)),
+			},
+			IsOwner: true,
+		},
+	}, nil)
+
+	stdout, _, err := testutil.Exec(t, env, "account", "member", "describe", "user-001")
+	require.NoError(t, err)
+	assert.Contains(t, stdout, "user-001")
+	assert.Contains(t, stdout, "owner@example.com")
+	assert.Contains(t, stdout, "yes")
+
+	req, ok := env.AccountServer.GetAccountMemberCalls.Last()
+	require.True(t, ok)
+	assert.Equal(t, "test-account-id", req.GetAccountId())
+	assert.Equal(t, "user-001", req.GetUserId())
+}
+
+func TestMemberDescribe_NonOwner(t *testing.T) {
+	env := testutil.NewTestEnv(t)
+
+	env.AccountServer.GetAccountMemberCalls.Returns(&accountv1.GetAccountMemberResponse{
+		AccountMember: &accountv1.AccountMember{
+			AccountMember: &iamv1.User{
+				Id:    "user-002",
+				Email: "member@example.com",
+			},
+			IsOwner: false,
+		},
+	}, nil)
+
+	stdout, _, err := testutil.Exec(t, env, "account", "member", "describe", "user-002")
+	require.NoError(t, err)
+	assert.Contains(t, stdout, "user-002")
+	assert.Contains(t, stdout, "no")
+}
+
+func TestMemberDescribe_JSONOutput(t *testing.T) {
+	env := testutil.NewTestEnv(t)
+
+	env.AccountServer.GetAccountMemberCalls.Returns(&accountv1.GetAccountMemberResponse{
+		AccountMember: &accountv1.AccountMember{
+			AccountMember: &iamv1.User{Id: "user-json", Email: "json@example.com"},
+			IsOwner:       true,
+		},
+	}, nil)
+
+	stdout, _, err := testutil.Exec(t, env, "account", "member", "describe", "user-json", "--json")
+	require.NoError(t, err)
+
+	var result struct {
+		AccountMember struct {
+			ID    string `json:"id"`
+			Email string `json:"email"`
+		} `json:"accountMember"`
+		IsOwner bool `json:"isOwner"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(stdout), &result))
+	assert.Equal(t, "user-json", result.AccountMember.ID)
+	assert.True(t, result.IsOwner)
+}
+
+func TestMemberDescribe_BackendError(t *testing.T) {
+	env := testutil.NewTestEnv(t)
+
+	env.AccountServer.GetAccountMemberCalls.Returns(nil, fmt.Errorf("not found"))
+
+	_, _, err := testutil.Exec(t, env, "account", "member", "describe", "user-bad")
+	require.Error(t, err)
+}
+
+func TestMemberDescribe_MissingArgs(t *testing.T) {
+	env := testutil.NewTestEnv(t)
+
+	_, _, err := testutil.Exec(t, env, "account", "member", "describe")
+	require.Error(t, err)
+}

--- a/internal/cmd/account/member_list.go
+++ b/internal/cmd/account/member_list.go
@@ -1,0 +1,72 @@
+package account
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	accountv1 "github.com/qdrant/qdrant-cloud-public-api/gen/go/qdrant/cloud/account/v1"
+
+	"github.com/qdrant/qcloud-cli/internal/cmd/base"
+	"github.com/qdrant/qcloud-cli/internal/cmd/output"
+	"github.com/qdrant/qcloud-cli/internal/state"
+)
+
+func newMemberListCommand(s *state.State) *cobra.Command {
+	return base.ListCmd[*accountv1.ListAccountMembersResponse]{
+		Use:   "list",
+		Short: "List account members",
+		Long: `List all members of the current account.
+
+Each member has an associated user record and an ownership flag. Use
+"qcloud iam user list" to see users with their status, or this command to
+see who is in the account and who owns it.`,
+		Example: `# List all members
+qcloud account member list
+
+# Output as JSON
+qcloud account member list --json`,
+		Fetch: func(s *state.State, cmd *cobra.Command) (*accountv1.ListAccountMembersResponse, error) {
+			ctx := cmd.Context()
+			client, err := s.Client(ctx)
+			if err != nil {
+				return nil, err
+			}
+
+			accountID, err := s.AccountID()
+			if err != nil {
+				return nil, err
+			}
+
+			resp, err := client.Account().ListAccountMembers(ctx, &accountv1.ListAccountMembersRequest{
+				AccountId: accountID,
+			})
+			if err != nil {
+				return nil, fmt.Errorf("failed to list account members: %w", err)
+			}
+
+			return resp, nil
+		},
+		PrintText: func(_ *cobra.Command, w io.Writer, resp *accountv1.ListAccountMembersResponse) error {
+			t := output.NewTable[*accountv1.AccountMember](w)
+			t.AddField("ID", func(v *accountv1.AccountMember) string {
+				return v.GetAccountMember().GetId()
+			})
+			t.AddField("EMAIL", func(v *accountv1.AccountMember) string {
+				return v.GetAccountMember().GetEmail()
+			})
+			t.AddField("OWNER", func(v *accountv1.AccountMember) string {
+				return output.BoolMark(v.GetIsOwner())
+			})
+			t.AddField("CREATED", func(v *accountv1.AccountMember) string {
+				if v.GetAccountMember().GetCreatedAt() != nil {
+					return output.HumanTime(v.GetAccountMember().GetCreatedAt().AsTime())
+				}
+				return ""
+			})
+			t.Write(resp.GetItems())
+			return nil
+		},
+	}.CobraCommand(s)
+}

--- a/internal/cmd/account/member_list_test.go
+++ b/internal/cmd/account/member_list_test.go
@@ -1,0 +1,108 @@
+package account_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	accountv1 "github.com/qdrant/qdrant-cloud-public-api/gen/go/qdrant/cloud/account/v1"
+	iamv1 "github.com/qdrant/qdrant-cloud-public-api/gen/go/qdrant/cloud/iam/v1"
+
+	"github.com/qdrant/qcloud-cli/internal/testutil"
+)
+
+func TestMemberList_TableOutput(t *testing.T) {
+	env := testutil.NewTestEnv(t, testutil.WithAccountID("test-account-id"))
+
+	env.AccountServer.ListAccountMembersCalls.Returns(&accountv1.ListAccountMembersResponse{
+		Items: []*accountv1.AccountMember{
+			{
+				AccountMember: &iamv1.User{
+					Id:        "user-001",
+					Email:     "owner@example.com",
+					CreatedAt: timestamppb.New(time.Now().Add(-72 * time.Hour)),
+				},
+				IsOwner: true,
+			},
+			{
+				AccountMember: &iamv1.User{
+					Id:        "user-002",
+					Email:     "member@example.com",
+					CreatedAt: timestamppb.New(time.Now().Add(-24 * time.Hour)),
+				},
+				IsOwner: false,
+			},
+		},
+	}, nil)
+
+	stdout, _, err := testutil.Exec(t, env, "account", "member", "list")
+	require.NoError(t, err)
+	assert.Contains(t, stdout, "ID")
+	assert.Contains(t, stdout, "EMAIL")
+	assert.Contains(t, stdout, "OWNER")
+	assert.Contains(t, stdout, "CREATED")
+	assert.Contains(t, stdout, "user-001")
+	assert.Contains(t, stdout, "owner@example.com")
+	assert.Contains(t, stdout, "yes")
+	assert.Contains(t, stdout, "user-002")
+	assert.Contains(t, stdout, "member@example.com")
+
+	req, ok := env.AccountServer.ListAccountMembersCalls.Last()
+	require.True(t, ok)
+	assert.Equal(t, "test-account-id", req.GetAccountId())
+}
+
+func TestMemberList_JSONOutput(t *testing.T) {
+	env := testutil.NewTestEnv(t)
+
+	env.AccountServer.ListAccountMembersCalls.Returns(&accountv1.ListAccountMembersResponse{
+		Items: []*accountv1.AccountMember{
+			{
+				AccountMember: &iamv1.User{Id: "user-json", Email: "json@example.com"},
+				IsOwner:       true,
+			},
+		},
+	}, nil)
+
+	stdout, _, err := testutil.Exec(t, env, "account", "member", "list", "--json")
+	require.NoError(t, err)
+
+	var result struct {
+		Items []struct {
+			AccountMember struct {
+				ID    string `json:"id"`
+				Email string `json:"email"`
+			} `json:"accountMember"`
+			IsOwner bool `json:"isOwner"`
+		} `json:"items"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(stdout), &result))
+	require.Len(t, result.Items, 1)
+	assert.Equal(t, "user-json", result.Items[0].AccountMember.ID)
+	assert.True(t, result.Items[0].IsOwner)
+}
+
+func TestMemberList_BackendError(t *testing.T) {
+	env := testutil.NewTestEnv(t)
+
+	env.AccountServer.ListAccountMembersCalls.Returns(nil, fmt.Errorf("internal error"))
+
+	_, _, err := testutil.Exec(t, env, "account", "member", "list")
+	require.Error(t, err)
+}
+
+func TestMemberList_Empty(t *testing.T) {
+	env := testutil.NewTestEnv(t)
+
+	env.AccountServer.ListAccountMembersCalls.Returns(&accountv1.ListAccountMembersResponse{}, nil)
+
+	stdout, _, err := testutil.Exec(t, env, "account", "member", "list")
+	require.NoError(t, err)
+	assert.Contains(t, stdout, "ID")
+	assert.Contains(t, stdout, "EMAIL")
+}

--- a/internal/cmd/account/update.go
+++ b/internal/cmd/account/update.go
@@ -1,0 +1,109 @@
+package account
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+	"google.golang.org/protobuf/proto"
+
+	accountv1 "github.com/qdrant/qdrant-cloud-public-api/gen/go/qdrant/cloud/account/v1"
+
+	"github.com/qdrant/qcloud-cli/internal/cmd/base"
+	"github.com/qdrant/qcloud-cli/internal/state"
+)
+
+func newUpdateCommand(s *state.State) *cobra.Command {
+	return base.UpdateCmd[*accountv1.Account]{
+		Long: `Update an account's name or company information.
+
+If no account ID is provided, the current account (from --account-id, the
+active context, or the QDRANT_CLOUD_ACCOUNT_ID environment variable) is used.
+
+Only flags that are explicitly set are applied. Unset flags leave the existing
+values unchanged.`,
+		Example: `# Rename the current account
+qcloud account update --name "Production Account"
+
+# Update company information on a specific account
+qcloud account update a1b2c3d4-e5f6-7890-abcd-ef1234567890 --company-name "Acme Corp" --company-domain acme.com
+
+# Output as JSON
+qcloud account update --name "New Name" --json`,
+		BaseCobraCommand: func() *cobra.Command {
+			cmd := &cobra.Command{
+				Use:   "update [account-id]",
+				Short: "Update an account",
+				Args:  cobra.MaximumNArgs(1),
+			}
+			cmd.Flags().String("name", "", "New account name")
+			cmd.Flags().String("company-name", "", "Company name")
+			cmd.Flags().String("company-domain", "", "Company domain")
+			return cmd
+		},
+		Fetch: func(s *state.State, cmd *cobra.Command, args []string) (*accountv1.Account, error) {
+			ctx := cmd.Context()
+			client, err := s.Client(ctx)
+			if err != nil {
+				return nil, err
+			}
+
+			accountID, err := resolveAccountID(s, args)
+			if err != nil {
+				return nil, err
+			}
+
+			resp, err := client.Account().GetAccount(ctx, &accountv1.GetAccountRequest{
+				AccountId: accountID,
+			})
+			if err != nil {
+				return nil, fmt.Errorf("failed to get account: %w", err)
+			}
+
+			return resp.GetAccount(), nil
+		},
+		Update: func(s *state.State, cmd *cobra.Command, acct *accountv1.Account) (*accountv1.Account, error) {
+			ctx := cmd.Context()
+			client, err := s.Client(ctx)
+			if err != nil {
+				return nil, err
+			}
+
+			updated := proto.CloneOf(acct)
+
+			if cmd.Flags().Changed("name") {
+				name, _ := cmd.Flags().GetString("name")
+				updated.Name = name
+			}
+
+			if cmd.Flags().Changed("company-name") || cmd.Flags().Changed("company-domain") {
+				if updated.Company == nil {
+					updated.Company = &accountv1.Company{}
+				}
+				if cmd.Flags().Changed("company-name") {
+					name, _ := cmd.Flags().GetString("company-name")
+					updated.Company.Name = name
+				}
+				if cmd.Flags().Changed("company-domain") {
+					domain, _ := cmd.Flags().GetString("company-domain")
+					updated.Company.Domain = &domain
+				}
+			}
+
+			resp, err := client.Account().UpdateAccount(ctx, &accountv1.UpdateAccountRequest{
+				Account: updated,
+			})
+			if err != nil {
+				return nil, fmt.Errorf("failed to update account: %w", err)
+			}
+
+			return resp.GetAccount(), nil
+		},
+		PrintResource: func(_ *cobra.Command, out io.Writer, acct *accountv1.Account) {
+			if acct == nil {
+				return
+			}
+			fmt.Fprintf(out, "Account %s (%s) updated successfully.\n", acct.GetId(), acct.GetName())
+		},
+	}.CobraCommand(s)
+}

--- a/internal/cmd/account/update_test.go
+++ b/internal/cmd/account/update_test.go
@@ -1,0 +1,147 @@
+package account_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	accountv1 "github.com/qdrant/qdrant-cloud-public-api/gen/go/qdrant/cloud/account/v1"
+
+	"github.com/qdrant/qcloud-cli/internal/testutil"
+)
+
+func TestAccountUpdate_Name(t *testing.T) {
+	env := testutil.NewTestEnv(t)
+
+	env.AccountServer.GetAccountCalls.Returns(&accountv1.GetAccountResponse{
+		Account: &accountv1.Account{
+			Id:   "acct-001",
+			Name: "Old Name",
+		},
+	}, nil)
+	env.AccountServer.UpdateAccountCalls.Always(func(_ context.Context, req *accountv1.UpdateAccountRequest) (*accountv1.UpdateAccountResponse, error) {
+		return &accountv1.UpdateAccountResponse{Account: req.GetAccount()}, nil
+	})
+
+	stdout, _, err := testutil.Exec(t, env, "account", "update", "acct-001", "--name", "New Name")
+	require.NoError(t, err)
+	assert.Contains(t, stdout, "acct-001")
+	assert.Contains(t, stdout, "New Name")
+	assert.Contains(t, stdout, "updated successfully")
+
+	req, ok := env.AccountServer.UpdateAccountCalls.Last()
+	require.True(t, ok)
+	assert.Equal(t, "New Name", req.GetAccount().GetName())
+}
+
+func TestAccountUpdate_CompanyInfo(t *testing.T) {
+	env := testutil.NewTestEnv(t)
+
+	env.AccountServer.GetAccountCalls.Returns(&accountv1.GetAccountResponse{
+		Account: &accountv1.Account{
+			Id:   "acct-001",
+			Name: "My Account",
+		},
+	}, nil)
+	env.AccountServer.UpdateAccountCalls.Always(func(_ context.Context, req *accountv1.UpdateAccountRequest) (*accountv1.UpdateAccountResponse, error) {
+		return &accountv1.UpdateAccountResponse{Account: req.GetAccount()}, nil
+	})
+
+	_, _, err := testutil.Exec(t, env, "account", "update", "acct-001",
+		"--company-name", "Acme Corp",
+		"--company-domain", "acme.com",
+	)
+	require.NoError(t, err)
+
+	req, ok := env.AccountServer.UpdateAccountCalls.Last()
+	require.True(t, ok)
+	assert.Equal(t, "Acme Corp", req.GetAccount().GetCompany().GetName())
+	assert.Equal(t, "acme.com", req.GetAccount().GetCompany().GetDomain())
+}
+
+func TestAccountUpdate_DefaultsToCurrentAccount(t *testing.T) {
+	env := testutil.NewTestEnv(t, testutil.WithAccountID("default-acct"))
+
+	env.AccountServer.GetAccountCalls.Returns(&accountv1.GetAccountResponse{
+		Account: &accountv1.Account{
+			Id:   "default-acct",
+			Name: "Default",
+		},
+	}, nil)
+	env.AccountServer.UpdateAccountCalls.Always(func(_ context.Context, req *accountv1.UpdateAccountRequest) (*accountv1.UpdateAccountResponse, error) {
+		return &accountv1.UpdateAccountResponse{Account: req.GetAccount()}, nil
+	})
+
+	_, _, err := testutil.Exec(t, env, "account", "update", "--name", "Updated")
+	require.NoError(t, err)
+
+	getReq, ok := env.AccountServer.GetAccountCalls.Last()
+	require.True(t, ok)
+	assert.Equal(t, "default-acct", getReq.GetAccountId())
+}
+
+func TestAccountUpdate_JSONOutput(t *testing.T) {
+	env := testutil.NewTestEnv(t)
+
+	env.AccountServer.GetAccountCalls.Returns(&accountv1.GetAccountResponse{
+		Account: &accountv1.Account{Id: "acct-001", Name: "Old"},
+	}, nil)
+	env.AccountServer.UpdateAccountCalls.Always(func(_ context.Context, req *accountv1.UpdateAccountRequest) (*accountv1.UpdateAccountResponse, error) {
+		return &accountv1.UpdateAccountResponse{Account: req.GetAccount()}, nil
+	})
+
+	stdout, _, err := testutil.Exec(t, env, "account", "update", "acct-001", "--name", "New", "--json")
+	require.NoError(t, err)
+
+	var result struct {
+		ID   string `json:"id"`
+		Name string `json:"name"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(stdout), &result))
+	assert.Equal(t, "acct-001", result.ID)
+	assert.Equal(t, "New", result.Name)
+}
+
+func TestAccountUpdate_BackendError(t *testing.T) {
+	env := testutil.NewTestEnv(t)
+
+	env.AccountServer.GetAccountCalls.Returns(&accountv1.GetAccountResponse{
+		Account: &accountv1.Account{Id: "acct-001", Name: "X"},
+	}, nil)
+	env.AccountServer.UpdateAccountCalls.Returns(nil, fmt.Errorf("permission denied"))
+
+	_, _, err := testutil.Exec(t, env, "account", "update", "acct-001", "--name", "Y")
+	require.Error(t, err)
+}
+
+func TestAccountUpdate_PreservesUnchangedFields(t *testing.T) {
+	env := testutil.NewTestEnv(t)
+
+	env.AccountServer.GetAccountCalls.Returns(&accountv1.GetAccountResponse{
+		Account: &accountv1.Account{
+			Id:   "acct-001",
+			Name: "Original Name",
+			Company: &accountv1.Company{
+				Name:   "Original Corp",
+				Domain: new("original.com"),
+			},
+		},
+	}, nil)
+	env.AccountServer.UpdateAccountCalls.Always(func(_ context.Context, req *accountv1.UpdateAccountRequest) (*accountv1.UpdateAccountResponse, error) {
+		return &accountv1.UpdateAccountResponse{Account: req.GetAccount()}, nil
+	})
+
+	// Only change company-name, leave name and company-domain unchanged
+	_, _, err := testutil.Exec(t, env, "account", "update", "acct-001", "--company-name", "New Corp")
+	require.NoError(t, err)
+
+	req, ok := env.AccountServer.UpdateAccountCalls.Last()
+	require.True(t, ok)
+	assert.Equal(t, "Original Name", req.GetAccount().GetName())
+	assert.Equal(t, "New Corp", req.GetAccount().GetCompany().GetName())
+	assert.Equal(t, "original.com", req.GetAccount().GetCompany().GetDomain())
+}

--- a/internal/cmd/completion/completion.go
+++ b/internal/cmd/completion/completion.go
@@ -3,6 +3,7 @@ package completion
 import (
 	"github.com/spf13/cobra"
 
+	accountv1 "github.com/qdrant/qdrant-cloud-public-api/gen/go/qdrant/cloud/account/v1"
 	authv1 "github.com/qdrant/qdrant-cloud-public-api/gen/go/qdrant/cloud/auth/v1"
 	backupv1 "github.com/qdrant/qdrant-cloud-public-api/gen/go/qdrant/cloud/cluster/backup/v1"
 	clusterv1 "github.com/qdrant/qdrant-cloud-public-api/gen/go/qdrant/cloud/cluster/v1"
@@ -224,6 +225,65 @@ func VersionCompletion(s *state.State) func(*cobra.Command, []string, string) ([
 				entry += "\t" + desc
 			}
 			completions = append(completions, entry)
+		}
+		return completions, cobra.ShellCompDirectiveNoFileComp
+	}
+}
+
+// AccountIDCompletion returns a ValidArgsFunction that completes account IDs.
+func AccountIDCompletion(s *state.State) func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
+	return func(cmd *cobra.Command, args []string, _ string) ([]string, cobra.ShellCompDirective) {
+		if len(args) > 0 {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+
+		ctx := cmd.Context()
+		client, err := s.Client(ctx)
+		if err != nil {
+			return nil, cobra.ShellCompDirectiveError
+		}
+
+		resp, err := client.Account().ListAccounts(ctx, &accountv1.ListAccountsRequest{})
+		if err != nil {
+			return nil, cobra.ShellCompDirectiveError
+		}
+
+		completions := make([]string, 0, len(resp.GetItems()))
+		for _, a := range resp.GetItems() {
+			completions = append(completions, a.GetId()+"\t"+a.GetName())
+		}
+		return completions, cobra.ShellCompDirectiveNoFileComp
+	}
+}
+
+// AccountMemberIDCompletion returns a ValidArgsFunction that completes account member user IDs.
+func AccountMemberIDCompletion(s *state.State) func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
+	return func(cmd *cobra.Command, args []string, _ string) ([]string, cobra.ShellCompDirective) {
+		if len(args) > 0 {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+
+		ctx := cmd.Context()
+		client, err := s.Client(ctx)
+		if err != nil {
+			return nil, cobra.ShellCompDirectiveError
+		}
+
+		accountID, err := s.AccountID()
+		if err != nil {
+			return nil, cobra.ShellCompDirectiveError
+		}
+
+		resp, err := client.Account().ListAccountMembers(ctx, &accountv1.ListAccountMembersRequest{
+			AccountId: accountID,
+		})
+		if err != nil {
+			return nil, cobra.ShellCompDirectiveError
+		}
+
+		completions := make([]string, 0, len(resp.GetItems()))
+		for _, m := range resp.GetItems() {
+			completions = append(completions, m.GetAccountMember().GetId()+"\t"+m.GetAccountMember().GetEmail())
 		}
 		return completions, cobra.ShellCompDirectiveNoFileComp
 	}

--- a/internal/qcloudapi/client.go
+++ b/internal/qcloudapi/client.go
@@ -7,6 +7,7 @@ import (
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/metadata"
 
+	accountv1 "github.com/qdrant/qdrant-cloud-public-api/gen/go/qdrant/cloud/account/v1"
 	authv1 "github.com/qdrant/qdrant-cloud-public-api/gen/go/qdrant/cloud/auth/v1"
 	bookingv1 "github.com/qdrant/qdrant-cloud-public-api/gen/go/qdrant/cloud/booking/v1"
 	clusterauthv2 "github.com/qdrant/qdrant-cloud-public-api/gen/go/qdrant/cloud/cluster/auth/v2"
@@ -28,6 +29,7 @@ type Client struct {
 	hybrid         hybridv1.HybridCloudServiceClient
 	monitoring     monitoringv1.MonitoringServiceClient
 	auth           authv1.AuthServiceClient
+	account        accountv1.AccountServiceClient
 }
 
 // New creates a new gRPC client connected to the given endpoint with the given API key.
@@ -60,6 +62,7 @@ func newFromConn(conn *grpc.ClientConn) *Client {
 		hybrid:         hybridv1.NewHybridCloudServiceClient(conn),
 		monitoring:     monitoringv1.NewMonitoringServiceClient(conn),
 		auth:           authv1.NewAuthServiceClient(conn),
+		account:        accountv1.NewAccountServiceClient(conn),
 	}
 }
 
@@ -101,6 +104,11 @@ func (c *Client) Monitoring() monitoringv1.MonitoringServiceClient {
 // Auth returns the AuthService gRPC client.
 func (c *Client) Auth() authv1.AuthServiceClient {
 	return c.auth
+}
+
+// Account returns the AccountService gRPC client.
+func (c *Client) Account() accountv1.AccountServiceClient {
+	return c.account
 }
 
 // Close closes the underlying gRPC connection.

--- a/internal/testutil/fake_account.go
+++ b/internal/testutil/fake_account.go
@@ -1,0 +1,49 @@
+package testutil
+
+import (
+	"context"
+
+	accountv1 "github.com/qdrant/qdrant-cloud-public-api/gen/go/qdrant/cloud/account/v1"
+)
+
+// FakeAccountService is a test fake that implements AccountServiceServer.
+// Use the *Calls fields to configure responses and inspect captured requests.
+type FakeAccountService struct {
+	accountv1.UnimplementedAccountServiceServer
+
+	ListAccountsCalls       MethodSpy[*accountv1.ListAccountsRequest, *accountv1.ListAccountsResponse]
+	GetAccountCalls         MethodSpy[*accountv1.GetAccountRequest, *accountv1.GetAccountResponse]
+	UpdateAccountCalls      MethodSpy[*accountv1.UpdateAccountRequest, *accountv1.UpdateAccountResponse]
+	ListAccountMembersCalls MethodSpy[*accountv1.ListAccountMembersRequest, *accountv1.ListAccountMembersResponse]
+	GetAccountMemberCalls   MethodSpy[*accountv1.GetAccountMemberRequest, *accountv1.GetAccountMemberResponse]
+}
+
+// ListAccounts records the call and dispatches via ListAccountsCalls.
+func (f *FakeAccountService) ListAccounts(ctx context.Context, req *accountv1.ListAccountsRequest) (*accountv1.ListAccountsResponse, error) {
+	f.ListAccountsCalls.record(req)
+	return f.ListAccountsCalls.dispatch(ctx, req, f.UnimplementedAccountServiceServer.ListAccounts)
+}
+
+// GetAccount records the call and dispatches via GetAccountCalls.
+func (f *FakeAccountService) GetAccount(ctx context.Context, req *accountv1.GetAccountRequest) (*accountv1.GetAccountResponse, error) {
+	f.GetAccountCalls.record(req)
+	return f.GetAccountCalls.dispatch(ctx, req, f.UnimplementedAccountServiceServer.GetAccount)
+}
+
+// UpdateAccount records the call and dispatches via UpdateAccountCalls.
+func (f *FakeAccountService) UpdateAccount(ctx context.Context, req *accountv1.UpdateAccountRequest) (*accountv1.UpdateAccountResponse, error) {
+	f.UpdateAccountCalls.record(req)
+	return f.UpdateAccountCalls.dispatch(ctx, req, f.UnimplementedAccountServiceServer.UpdateAccount)
+}
+
+// ListAccountMembers records the call and dispatches via ListAccountMembersCalls.
+func (f *FakeAccountService) ListAccountMembers(ctx context.Context, req *accountv1.ListAccountMembersRequest) (*accountv1.ListAccountMembersResponse, error) {
+	f.ListAccountMembersCalls.record(req)
+	return f.ListAccountMembersCalls.dispatch(ctx, req, f.UnimplementedAccountServiceServer.ListAccountMembers)
+}
+
+// GetAccountMember records the call and dispatches via GetAccountMemberCalls.
+func (f *FakeAccountService) GetAccountMember(ctx context.Context, req *accountv1.GetAccountMemberRequest) (*accountv1.GetAccountMemberResponse, error) {
+	f.GetAccountMemberCalls.record(req)
+	return f.GetAccountMemberCalls.dispatch(ctx, req, f.UnimplementedAccountServiceServer.GetAccountMember)
+}

--- a/internal/testutil/server.go
+++ b/internal/testutil/server.go
@@ -11,6 +11,7 @@ import (
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/test/bufconn"
 
+	accountv1 "github.com/qdrant/qdrant-cloud-public-api/gen/go/qdrant/cloud/account/v1"
 	authv1 "github.com/qdrant/qdrant-cloud-public-api/gen/go/qdrant/cloud/auth/v1"
 	bookingv1 "github.com/qdrant/qdrant-cloud-public-api/gen/go/qdrant/cloud/booking/v1"
 	clusterauthv2 "github.com/qdrant/qdrant-cloud-public-api/gen/go/qdrant/cloud/cluster/auth/v2"
@@ -63,6 +64,7 @@ type TestEnv struct {
 	HybridServer         *FakeHybridService
 	MonitoringServer     *FakeMonitoringService
 	AuthServer           *FakeAuthService
+	AccountServer        *FakeAccountService
 	Capture              *RequestCapture
 	Cleanup              func()
 }
@@ -114,6 +116,7 @@ func newBaseTestEnv(t *testing.T, cfg *envConfig) *TestEnv {
 	fakeHybrid := &FakeHybridService{}
 	fakeMonitoring := &FakeMonitoringService{}
 	fakeAuth := &FakeAuthService{}
+	fakeAccount := &FakeAccountService{}
 	capture := &RequestCapture{}
 
 	// Start gRPC server on bufconn.
@@ -127,6 +130,7 @@ func newBaseTestEnv(t *testing.T, cfg *envConfig) *TestEnv {
 	hybridv1.RegisterHybridCloudServiceServer(srv, fakeHybrid)
 	monitoringv1.RegisterMonitoringServiceServer(srv, fakeMonitoring)
 	authv1.RegisterAuthServiceServer(srv, fakeAuth)
+	accountv1.RegisterAccountServiceServer(srv, fakeAccount)
 
 	go func() {
 		_ = srv.Serve(lis)
@@ -178,6 +182,7 @@ func newBaseTestEnv(t *testing.T, cfg *envConfig) *TestEnv {
 		HybridServer:         fakeHybrid,
 		MonitoringServer:     fakeMonitoring,
 		AuthServer:           fakeAuth,
+		AccountServer:        fakeAccount,
 		Capture:              capture,
 		Cleanup:              cleanup,
 	}


### PR DESCRIPTION
Adds a new `account` command group for managing Qdrant Cloud accounts via the management API.

## Commands

- `qcloud account list` -- list all accounts accessible by the current management key
- `qcloud account describe <account-id>` -- show details for a specific account
- `qcloud account update <account-id>` -- update account properties
- `qcloud account member list` -- list members of the current account
- `qcloud account member describe <member-id>` -- show details for a specific member
