### PR TITLE
feat: add docs generation from the cobra commands so that further LLM models swallow the CLI shape

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,3 +68,22 @@ jobs:
 
       - if: failure()
         run: echo "::error::Check failed, please run 'go mod tidy' and commit the changes."
+
+  docs-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Set up tools
+        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+        with:
+          version: 2026.3.8
+
+      - name: Check docs are up to date
+        run: make docs-check
+
+      - if: failure()
+        run: echo "::error::Check failed, please run 'make docs' and commit the changes."

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo unknown)
 
-.PHONY: build debug debug-run test lint format clean bootstrap
+.PHONY: build debug debug-run test lint format clean bootstrap docs docs-check
 
 build:
 	CGO_ENABLED=0 go build -ldflags "-X main.version=$(VERSION)" -o build/qcloud ./cmd/qcloud
@@ -31,4 +31,11 @@ bootstrap:
 	@command -v mise > /dev/null 2>&1 || \
 		{ echo "mise is not installed. Install it from https://mise.jdx.dev/installing-mise.html"; exit 1; }
 	mise install
+
+docs:
+	go run ./cmd/docgen ./docs/reference
+
+docs-check: docs
+	@git diff --exit-code docs/reference/ || \
+		(echo "docs/reference is out of date — run 'make docs' and commit the result" && exit 1)
 

--- a/cmd/docgen/main.go
+++ b/cmd/docgen/main.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"log"
+	"os"
+
+	"github.com/spf13/cobra/doc"
+
+	"github.com/qdrant/qcloud-cli/internal/cli"
+	"github.com/qdrant/qcloud-cli/internal/state"
+)
+
+func main() {
+	outDir := "./docs/reference"
+	if len(os.Args) > 1 {
+		outDir = os.Args[1]
+	}
+
+	if err := os.MkdirAll(outDir, 0755); err != nil {
+		log.Fatalf("create output dir: %v", err)
+	}
+
+	s := state.New("dev")
+	root := cli.NewRootCommand(s)
+	root.DisableAutoGenTag = true
+
+	if err := doc.GenMarkdownTree(root, outDir); err != nil {
+		log.Fatalf("generate docs: %v", err)
+	}
+}

--- a/docs/reference/qcloud.md
+++ b/docs/reference/qcloud.md
@@ -1,0 +1,41 @@
+## qcloud
+
+Qdrant Cloud CLI
+
+### Synopsis
+
+The command-line interface for Qdrant Cloud.
+
+Get started:
+  qcloud context set default --api-key <KEY> --account-id <ID>
+  qcloud cluster list
+
+Documentation: https://github.com/qdrant/qcloud-cli
+
+### Options
+
+```
+      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug               Enable debug logging to stderr
+      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+  -h, --help                help for qcloud
+      --json                Output as JSON
+```
+
+### SEE ALSO
+
+* [qcloud account](qcloud_account.md)	 - Manage Qdrant Cloud accounts
+* [qcloud backup](qcloud_backup.md)	 - Manage Qdrant Cloud backups
+* [qcloud cloud-provider](qcloud_cloud-provider.md)	 - Manage cloud providers
+* [qcloud cloud-region](qcloud_cloud-region.md)	 - Manage cloud regions
+* [qcloud cluster](qcloud_cluster.md)	 - Manage Qdrant Cloud clusters
+* [qcloud context](qcloud_context.md)	 - Manage named configuration contexts
+* [qcloud hybrid](qcloud_hybrid.md)	 - Manage hybrid cloud environments
+* [qcloud iam](qcloud_iam.md)	 - Manage IAM resources in Qdrant Cloud
+* [qcloud package](qcloud_package.md)	 - Manage packages
+* [qcloud self-upgrade](qcloud_self-upgrade.md)	 - Upgrade qcloud to the latest version
+* [qcloud version](qcloud_version.md)	 - Print the qcloud CLI version
+

--- a/docs/reference/qcloud_account.md
+++ b/docs/reference/qcloud_account.md
@@ -1,0 +1,38 @@
+## qcloud account
+
+Manage Qdrant Cloud accounts
+
+### Synopsis
+
+Manage Qdrant Cloud accounts and their members.
+
+Use these commands to list, inspect, and update accounts that the current
+management key has access to. Account member commands show who belongs to the
+current account and whether they are the owner.
+
+### Options
+
+```
+  -h, --help   help for account
+```
+
+### Options inherited from parent commands
+
+```
+      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug               Enable debug logging to stderr
+      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                Output as JSON
+```
+
+### SEE ALSO
+
+* [qcloud](qcloud.md)	 - Qdrant Cloud CLI
+* [qcloud account describe](qcloud_account_describe.md)	 - Describe an account
+* [qcloud account list](qcloud_account_list.md)	 - List accounts
+* [qcloud account member](qcloud_account_member.md)	 - Manage account members
+* [qcloud account update](qcloud_account_update.md)	 - Update an account
+

--- a/docs/reference/qcloud_account_describe.md
+++ b/docs/reference/qcloud_account_describe.md
@@ -1,0 +1,50 @@
+## qcloud account describe
+
+Describe an account
+
+### Synopsis
+
+Describe an account by its ID.
+
+If no account ID is provided, the current account (from --account-id, the
+active context, or the QDRANT_CLOUD_ACCOUNT_ID environment variable) is used.
+
+```
+qcloud account describe [account-id] [flags]
+```
+
+### Examples
+
+```
+# Describe the current account
+qcloud account describe
+
+# Describe a specific account
+qcloud account describe a1b2c3d4-e5f6-7890-abcd-ef1234567890
+
+# Output as JSON
+qcloud account describe --json
+```
+
+### Options
+
+```
+  -h, --help   help for describe
+```
+
+### Options inherited from parent commands
+
+```
+      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug               Enable debug logging to stderr
+      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                Output as JSON
+```
+
+### SEE ALSO
+
+* [qcloud account](qcloud_account.md)	 - Manage Qdrant Cloud accounts
+

--- a/docs/reference/qcloud_account_list.md
+++ b/docs/reference/qcloud_account_list.md
@@ -1,0 +1,48 @@
+## qcloud account list
+
+List accounts
+
+### Synopsis
+
+List all accounts associated with the authenticated management key.
+
+Returns every account the current API key has access to. No account ID is
+required because the server resolves accounts from the caller's credentials.
+
+```
+qcloud account list [flags]
+```
+
+### Examples
+
+```
+# List all accessible accounts
+qcloud account list
+
+# Output as JSON
+qcloud account list --json
+```
+
+### Options
+
+```
+  -h, --help         help for list
+      --no-headers   Do not print column headers
+```
+
+### Options inherited from parent commands
+
+```
+      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug               Enable debug logging to stderr
+      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                Output as JSON
+```
+
+### SEE ALSO
+
+* [qcloud account](qcloud_account.md)	 - Manage Qdrant Cloud accounts
+

--- a/docs/reference/qcloud_account_member.md
+++ b/docs/reference/qcloud_account_member.md
@@ -1,0 +1,36 @@
+## qcloud account member
+
+Manage account members
+
+### Synopsis
+
+Manage members of the current Qdrant Cloud account.
+
+Members are users who have been added to the account. Each member has an
+associated user record and an ownership flag indicating whether they are the
+account owner.
+
+### Options
+
+```
+  -h, --help   help for member
+```
+
+### Options inherited from parent commands
+
+```
+      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug               Enable debug logging to stderr
+      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                Output as JSON
+```
+
+### SEE ALSO
+
+* [qcloud account](qcloud_account.md)	 - Manage Qdrant Cloud accounts
+* [qcloud account member describe](qcloud_account_member_describe.md)	 - Describe an account member
+* [qcloud account member list](qcloud_account_member_list.md)	 - List account members
+

--- a/docs/reference/qcloud_account_member_describe.md
+++ b/docs/reference/qcloud_account_member_describe.md
@@ -1,0 +1,46 @@
+## qcloud account member describe
+
+Describe an account member
+
+### Synopsis
+
+Describe a member of the current account by their user ID.
+
+Shows the member's user details and whether they are the account owner.
+
+```
+qcloud account member describe <user-id> [flags]
+```
+
+### Examples
+
+```
+# Describe a member
+qcloud account member describe a1b2c3d4-e5f6-7890-abcd-ef1234567890
+
+# Output as JSON
+qcloud account member describe a1b2c3d4-e5f6-7890-abcd-ef1234567890 --json
+```
+
+### Options
+
+```
+  -h, --help   help for describe
+```
+
+### Options inherited from parent commands
+
+```
+      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug               Enable debug logging to stderr
+      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                Output as JSON
+```
+
+### SEE ALSO
+
+* [qcloud account member](qcloud_account_member.md)	 - Manage account members
+

--- a/docs/reference/qcloud_account_member_list.md
+++ b/docs/reference/qcloud_account_member_list.md
@@ -1,0 +1,49 @@
+## qcloud account member list
+
+List account members
+
+### Synopsis
+
+List all members of the current account.
+
+Each member has an associated user record and an ownership flag. Use
+"qcloud iam user list" to see users with their status, or this command to
+see who is in the account and who owns it.
+
+```
+qcloud account member list [flags]
+```
+
+### Examples
+
+```
+# List all members
+qcloud account member list
+
+# Output as JSON
+qcloud account member list --json
+```
+
+### Options
+
+```
+  -h, --help         help for list
+      --no-headers   Do not print column headers
+```
+
+### Options inherited from parent commands
+
+```
+      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug               Enable debug logging to stderr
+      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                Output as JSON
+```
+
+### SEE ALSO
+
+* [qcloud account member](qcloud_account_member.md)	 - Manage account members
+

--- a/docs/reference/qcloud_account_update.md
+++ b/docs/reference/qcloud_account_update.md
@@ -1,0 +1,56 @@
+## qcloud account update
+
+Update an account
+
+### Synopsis
+
+Update an account's name or company information.
+
+If no account ID is provided, the current account (from --account-id, the
+active context, or the QDRANT_CLOUD_ACCOUNT_ID environment variable) is used.
+
+Only flags that are explicitly set are applied. Unset flags leave the existing
+values unchanged.
+
+```
+qcloud account update [account-id] [flags]
+```
+
+### Examples
+
+```
+# Rename the current account
+qcloud account update --name "Production Account"
+
+# Update company information on a specific account
+qcloud account update a1b2c3d4-e5f6-7890-abcd-ef1234567890 --company-name "Acme Corp" --company-domain acme.com
+
+# Output as JSON
+qcloud account update --name "New Name" --json
+```
+
+### Options
+
+```
+      --company-domain string   Company domain
+      --company-name string     Company name
+  -h, --help                    help for update
+      --name string             New account name
+```
+
+### Options inherited from parent commands
+
+```
+      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug               Enable debug logging to stderr
+      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                Output as JSON
+```
+
+### SEE ALSO
+
+* [qcloud account](qcloud_account.md)	 - Manage Qdrant Cloud accounts
+

--- a/docs/reference/qcloud_backup.md
+++ b/docs/reference/qcloud_backup.md
@@ -1,0 +1,32 @@
+## qcloud backup
+
+Manage Qdrant Cloud backups
+
+### Options
+
+```
+  -h, --help   help for backup
+```
+
+### Options inherited from parent commands
+
+```
+      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug               Enable debug logging to stderr
+      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                Output as JSON
+```
+
+### SEE ALSO
+
+* [qcloud](qcloud.md)	 - Qdrant Cloud CLI
+* [qcloud backup create](qcloud_backup_create.md)	 - Create a backup for a cluster
+* [qcloud backup delete](qcloud_backup_delete.md)	 - Delete a backup
+* [qcloud backup describe](qcloud_backup_describe.md)	 - Describe a backup
+* [qcloud backup list](qcloud_backup_list.md)	 - List backups
+* [qcloud backup restore](qcloud_backup_restore.md)	 - Manage backup restores
+* [qcloud backup schedule](qcloud_backup_schedule.md)	 - Manage backup schedules
+

--- a/docs/reference/qcloud_backup_create.md
+++ b/docs/reference/qcloud_backup_create.md
@@ -1,0 +1,32 @@
+## qcloud backup create
+
+Create a backup for a cluster
+
+```
+qcloud backup create [flags]
+```
+
+### Options
+
+```
+      --cluster-id string       Cluster ID to back up (required)
+  -h, --help                    help for create
+      --retention-days uint32   Retention period in days (1-365) (required)
+```
+
+### Options inherited from parent commands
+
+```
+      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug               Enable debug logging to stderr
+      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                Output as JSON
+```
+
+### SEE ALSO
+
+* [qcloud backup](qcloud_backup.md)	 - Manage Qdrant Cloud backups
+

--- a/docs/reference/qcloud_backup_delete.md
+++ b/docs/reference/qcloud_backup_delete.md
@@ -1,0 +1,31 @@
+## qcloud backup delete
+
+Delete a backup
+
+```
+qcloud backup delete <backup-id> [flags]
+```
+
+### Options
+
+```
+  -f, --force   Skip confirmation prompt
+  -h, --help    help for delete
+```
+
+### Options inherited from parent commands
+
+```
+      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug               Enable debug logging to stderr
+      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                Output as JSON
+```
+
+### SEE ALSO
+
+* [qcloud backup](qcloud_backup.md)	 - Manage Qdrant Cloud backups
+

--- a/docs/reference/qcloud_backup_describe.md
+++ b/docs/reference/qcloud_backup_describe.md
@@ -1,0 +1,30 @@
+## qcloud backup describe
+
+Describe a backup
+
+```
+qcloud backup describe <backup-id> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for describe
+```
+
+### Options inherited from parent commands
+
+```
+      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug               Enable debug logging to stderr
+      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                Output as JSON
+```
+
+### SEE ALSO
+
+* [qcloud backup](qcloud_backup.md)	 - Manage Qdrant Cloud backups
+

--- a/docs/reference/qcloud_backup_list.md
+++ b/docs/reference/qcloud_backup_list.md
@@ -1,0 +1,32 @@
+## qcloud backup list
+
+List backups
+
+```
+qcloud backup list [flags]
+```
+
+### Options
+
+```
+      --cluster-id string   Filter by cluster ID
+  -h, --help                help for list
+      --no-headers          Do not print column headers
+```
+
+### Options inherited from parent commands
+
+```
+      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug               Enable debug logging to stderr
+      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                Output as JSON
+```
+
+### SEE ALSO
+
+* [qcloud backup](qcloud_backup.md)	 - Manage Qdrant Cloud backups
+

--- a/docs/reference/qcloud_backup_restore.md
+++ b/docs/reference/qcloud_backup_restore.md
@@ -1,0 +1,28 @@
+## qcloud backup restore
+
+Manage backup restores
+
+### Options
+
+```
+  -h, --help   help for restore
+```
+
+### Options inherited from parent commands
+
+```
+      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug               Enable debug logging to stderr
+      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                Output as JSON
+```
+
+### SEE ALSO
+
+* [qcloud backup](qcloud_backup.md)	 - Manage Qdrant Cloud backups
+* [qcloud backup restore list](qcloud_backup_restore_list.md)	 - List backup restores
+* [qcloud backup restore trigger](qcloud_backup_restore_trigger.md)	 - Trigger a restore from a backup
+

--- a/docs/reference/qcloud_backup_restore_list.md
+++ b/docs/reference/qcloud_backup_restore_list.md
@@ -1,0 +1,32 @@
+## qcloud backup restore list
+
+List backup restores
+
+```
+qcloud backup restore list [flags]
+```
+
+### Options
+
+```
+      --cluster-id string   Filter by cluster ID
+  -h, --help                help for list
+      --no-headers          Do not print column headers
+```
+
+### Options inherited from parent commands
+
+```
+      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug               Enable debug logging to stderr
+      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                Output as JSON
+```
+
+### SEE ALSO
+
+* [qcloud backup restore](qcloud_backup_restore.md)	 - Manage backup restores
+

--- a/docs/reference/qcloud_backup_restore_trigger.md
+++ b/docs/reference/qcloud_backup_restore_trigger.md
@@ -1,0 +1,31 @@
+## qcloud backup restore trigger
+
+Trigger a restore from a backup
+
+```
+qcloud backup restore trigger <backup-id> [flags]
+```
+
+### Options
+
+```
+  -f, --force   Skip confirmation prompt
+  -h, --help    help for trigger
+```
+
+### Options inherited from parent commands
+
+```
+      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug               Enable debug logging to stderr
+      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                Output as JSON
+```
+
+### SEE ALSO
+
+* [qcloud backup restore](qcloud_backup_restore.md)	 - Manage backup restores
+

--- a/docs/reference/qcloud_backup_schedule.md
+++ b/docs/reference/qcloud_backup_schedule.md
@@ -1,0 +1,31 @@
+## qcloud backup schedule
+
+Manage backup schedules
+
+### Options
+
+```
+  -h, --help   help for schedule
+```
+
+### Options inherited from parent commands
+
+```
+      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug               Enable debug logging to stderr
+      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                Output as JSON
+```
+
+### SEE ALSO
+
+* [qcloud backup](qcloud_backup.md)	 - Manage Qdrant Cloud backups
+* [qcloud backup schedule create](qcloud_backup_schedule_create.md)	 - Create a backup schedule for a cluster
+* [qcloud backup schedule delete](qcloud_backup_schedule_delete.md)	 - Delete a backup schedule
+* [qcloud backup schedule describe](qcloud_backup_schedule_describe.md)	 - Describe a backup schedule
+* [qcloud backup schedule list](qcloud_backup_schedule_list.md)	 - List backup schedules
+* [qcloud backup schedule update](qcloud_backup_schedule_update.md)	 - Update a backup schedule
+

--- a/docs/reference/qcloud_backup_schedule_create.md
+++ b/docs/reference/qcloud_backup_schedule_create.md
@@ -1,0 +1,33 @@
+## qcloud backup schedule create
+
+Create a backup schedule for a cluster
+
+```
+qcloud backup schedule create [flags]
+```
+
+### Options
+
+```
+      --cluster-id string       Cluster ID (required)
+  -h, --help                    help for create
+      --retention-days uint32   Retention period in days (1-365) (required)
+      --schedule string         Cron schedule expression in UTC (required), e.g. '0 2 * * *'
+```
+
+### Options inherited from parent commands
+
+```
+      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug               Enable debug logging to stderr
+      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                Output as JSON
+```
+
+### SEE ALSO
+
+* [qcloud backup schedule](qcloud_backup_schedule.md)	 - Manage backup schedules
+

--- a/docs/reference/qcloud_backup_schedule_delete.md
+++ b/docs/reference/qcloud_backup_schedule_delete.md
@@ -1,0 +1,32 @@
+## qcloud backup schedule delete
+
+Delete a backup schedule
+
+```
+qcloud backup schedule delete <schedule-id> [flags]
+```
+
+### Options
+
+```
+      --delete-backups   Also delete all backups created by this schedule
+  -f, --force            Skip confirmation prompt
+  -h, --help             help for delete
+```
+
+### Options inherited from parent commands
+
+```
+      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug               Enable debug logging to stderr
+      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                Output as JSON
+```
+
+### SEE ALSO
+
+* [qcloud backup schedule](qcloud_backup_schedule.md)	 - Manage backup schedules
+

--- a/docs/reference/qcloud_backup_schedule_describe.md
+++ b/docs/reference/qcloud_backup_schedule_describe.md
@@ -1,0 +1,37 @@
+## qcloud backup schedule describe
+
+Describe a backup schedule
+
+### Synopsis
+
+Describe a backup schedule.
+
+The --cluster-id flag is required because the API requires the cluster ID to look up a schedule by ID.
+
+```
+qcloud backup schedule describe <schedule-id> [flags]
+```
+
+### Options
+
+```
+      --cluster-id string   Cluster ID (required)
+  -h, --help                help for describe
+```
+
+### Options inherited from parent commands
+
+```
+      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug               Enable debug logging to stderr
+      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                Output as JSON
+```
+
+### SEE ALSO
+
+* [qcloud backup schedule](qcloud_backup_schedule.md)	 - Manage backup schedules
+

--- a/docs/reference/qcloud_backup_schedule_list.md
+++ b/docs/reference/qcloud_backup_schedule_list.md
@@ -1,0 +1,32 @@
+## qcloud backup schedule list
+
+List backup schedules
+
+```
+qcloud backup schedule list [flags]
+```
+
+### Options
+
+```
+      --cluster-id string   Filter by cluster ID
+  -h, --help                help for list
+      --no-headers          Do not print column headers
+```
+
+### Options inherited from parent commands
+
+```
+      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug               Enable debug logging to stderr
+      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                Output as JSON
+```
+
+### SEE ALSO
+
+* [qcloud backup schedule](qcloud_backup_schedule.md)	 - Manage backup schedules
+

--- a/docs/reference/qcloud_backup_schedule_update.md
+++ b/docs/reference/qcloud_backup_schedule_update.md
@@ -1,0 +1,39 @@
+## qcloud backup schedule update
+
+Update a backup schedule
+
+### Synopsis
+
+Update a backup schedule.
+
+The --cluster-id flag is required because the API requires the cluster ID to look up a schedule by ID.
+
+```
+qcloud backup schedule update <schedule-id> [flags]
+```
+
+### Options
+
+```
+      --cluster-id string       Cluster ID (required)
+  -h, --help                    help for update
+      --retention-days uint32   New retention period in days (1-365)
+      --schedule string         New cron schedule expression in UTC, e.g. '0 2 * * *'
+```
+
+### Options inherited from parent commands
+
+```
+      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug               Enable debug logging to stderr
+      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                Output as JSON
+```
+
+### SEE ALSO
+
+* [qcloud backup schedule](qcloud_backup_schedule.md)	 - Manage backup schedules
+

--- a/docs/reference/qcloud_cloud-provider.md
+++ b/docs/reference/qcloud_cloud-provider.md
@@ -1,0 +1,27 @@
+## qcloud cloud-provider
+
+Manage cloud providers
+
+### Options
+
+```
+  -h, --help   help for cloud-provider
+```
+
+### Options inherited from parent commands
+
+```
+      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug               Enable debug logging to stderr
+      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                Output as JSON
+```
+
+### SEE ALSO
+
+* [qcloud](qcloud.md)	 - Qdrant Cloud CLI
+* [qcloud cloud-provider list](qcloud_cloud-provider_list.md)	 - List available cloud providers
+

--- a/docs/reference/qcloud_cloud-provider_list.md
+++ b/docs/reference/qcloud_cloud-provider_list.md
@@ -1,0 +1,31 @@
+## qcloud cloud-provider list
+
+List available cloud providers
+
+```
+qcloud cloud-provider list [flags]
+```
+
+### Options
+
+```
+  -h, --help         help for list
+      --no-headers   Do not print column headers
+```
+
+### Options inherited from parent commands
+
+```
+      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug               Enable debug logging to stderr
+      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                Output as JSON
+```
+
+### SEE ALSO
+
+* [qcloud cloud-provider](qcloud_cloud-provider.md)	 - Manage cloud providers
+

--- a/docs/reference/qcloud_cloud-region.md
+++ b/docs/reference/qcloud_cloud-region.md
@@ -1,0 +1,27 @@
+## qcloud cloud-region
+
+Manage cloud regions
+
+### Options
+
+```
+  -h, --help   help for cloud-region
+```
+
+### Options inherited from parent commands
+
+```
+      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug               Enable debug logging to stderr
+      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                Output as JSON
+```
+
+### SEE ALSO
+
+* [qcloud](qcloud.md)	 - Qdrant Cloud CLI
+* [qcloud cloud-region list](qcloud_cloud-region_list.md)	 - List available cloud regions for a cloud provider
+

--- a/docs/reference/qcloud_cloud-region_list.md
+++ b/docs/reference/qcloud_cloud-region_list.md
@@ -1,0 +1,32 @@
+## qcloud cloud-region list
+
+List available cloud regions for a cloud provider
+
+```
+qcloud cloud-region list [flags]
+```
+
+### Options
+
+```
+      --cloud-provider string   Cloud provider ID (required)
+  -h, --help                    help for list
+      --no-headers              Do not print column headers
+```
+
+### Options inherited from parent commands
+
+```
+      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug               Enable debug logging to stderr
+      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                Output as JSON
+```
+
+### SEE ALSO
+
+* [qcloud cloud-region](qcloud_cloud-region.md)	 - Manage cloud regions
+

--- a/docs/reference/qcloud_cluster.md
+++ b/docs/reference/qcloud_cluster.md
@@ -1,0 +1,40 @@
+## qcloud cluster
+
+Manage Qdrant Cloud clusters
+
+### Options
+
+```
+  -h, --help   help for cluster
+```
+
+### Options inherited from parent commands
+
+```
+      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug               Enable debug logging to stderr
+      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                Output as JSON
+```
+
+### SEE ALSO
+
+* [qcloud](qcloud.md)	 - Qdrant Cloud CLI
+* [qcloud cluster create](qcloud_cluster_create.md)	 - Create a new cluster
+* [qcloud cluster create-from-backup](qcloud_cluster_create-from-backup.md)	 - Create a new cluster from a backup
+* [qcloud cluster delete](qcloud_cluster_delete.md)	 - Delete a cluster
+* [qcloud cluster describe](qcloud_cluster_describe.md)	 - Describe a cluster
+* [qcloud cluster key](qcloud_cluster_key.md)	 - Manage API keys for a cluster
+* [qcloud cluster list](qcloud_cluster_list.md)	 - List all clusters
+* [qcloud cluster logs](qcloud_cluster_logs.md)	 - Retrieve logs for a cluster
+* [qcloud cluster restart](qcloud_cluster_restart.md)	 - Restart a cluster
+* [qcloud cluster scale](qcloud_cluster_scale.md)	 - Scales the resources of a cluster
+* [qcloud cluster suspend](qcloud_cluster_suspend.md)	 - Suspend a cluster
+* [qcloud cluster unsuspend](qcloud_cluster_unsuspend.md)	 - Unsuspend a cluster
+* [qcloud cluster update](qcloud_cluster_update.md)	 - Update an existing cluster
+* [qcloud cluster version](qcloud_cluster_version.md)	 - Manage Qdrant versions
+* [qcloud cluster wait](qcloud_cluster_wait.md)	 - Wait for a cluster to become healthy
+

--- a/docs/reference/qcloud_cluster_create-from-backup.md
+++ b/docs/reference/qcloud_cluster_create-from-backup.md
@@ -1,0 +1,54 @@
+## qcloud cluster create-from-backup
+
+Create a new cluster from a backup
+
+### Synopsis
+
+Create a new Qdrant Cloud cluster seeded with the data from an existing backup.
+
+The new cluster is provisioned using the same configuration as the original cluster
+at the time the backup was taken. The backup must belong to the current account.
+
+```
+qcloud cluster create-from-backup [flags]
+```
+
+### Examples
+
+```
+# Create a cluster from a backup
+qcloud cluster create-from-backup --backup-id <backup-id> --name my-restored-cluster
+
+# Create a cluster from a backup and wait until it is healthy
+qcloud cluster create-from-backup --backup-id <backup-id> --name my-restored-cluster --wait
+
+# Create with a custom wait timeout
+qcloud cluster create-from-backup --backup-id <backup-id> --name my-restored-cluster --wait --wait-timeout 20m
+```
+
+### Options
+
+```
+      --backup-id string        ID of the backup to restore from (required)
+  -h, --help                    help for create-from-backup
+      --name string             Name for the new cluster (required)
+      --wait                    Wait for the cluster to become healthy
+      --wait-timeout duration   Maximum time to wait for cluster health (default 10m0s)
+```
+
+### Options inherited from parent commands
+
+```
+      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug               Enable debug logging to stderr
+      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                Output as JSON
+```
+
+### SEE ALSO
+
+* [qcloud cluster](qcloud_cluster.md)	 - Manage Qdrant Cloud clusters
+

--- a/docs/reference/qcloud_cluster_create.md
+++ b/docs/reference/qcloud_cluster_create.md
@@ -1,0 +1,106 @@
+## qcloud cluster create
+
+Create a new cluster
+
+```
+qcloud cluster create [flags]
+```
+
+### Examples
+
+```
+# Create a free-tier cluster
+qcloud cluster create --cloud-provider aws --cloud-region eu-central-1 --package free
+
+# Create a cluster with specific resources
+qcloud cluster create --cloud-provider aws --cloud-region eu-central-1 --cpu 0.5 --ram 4Gi
+
+# Create a cluster and wait for it to become healthy
+qcloud cluster create --cloud-provider aws --cloud-region eu-central-1 --cpu 2 --ram 8Gi --wait
+
+# Create with labels and extra disk
+qcloud cluster create --cloud-provider aws --cloud-region eu-central-1 --cpu 4 --ram 32Gi \
+  --disk 200Gi --label env=production --label team=search
+
+# Create a hybrid cloud cluster with a load balancer service type
+qcloud cluster create --cloud-provider hybrid --cloud-region my-env --cpu 2 --ram 8Gi \
+  --service-type load-balancer
+
+# Create a hybrid cluster with node selectors and tolerations
+qcloud cluster create --cloud-provider hybrid --cloud-region my-env --cpu 2 --ram 8Gi \
+  --node-selector disktype=ssd --toleration "dedicated=qdrant:NoSchedule"
+
+# Create a hybrid cluster with custom storage classes
+qcloud cluster create --cloud-provider hybrid --cloud-region my-env --cpu 4 --ram 16Gi \
+  --database-storage-class fast-ssd --snapshot-storage-class standard
+```
+
+### Options
+
+```
+      --allowed-ip stringArray                   Allowed client IP CIDR range (e.g. "10.0.0.0/8"); append '-' to remove; max 20
+      --annotation stringArray                   (cloud-provider: hybrid) Pod annotation ('key=value'); append '-' to remove, can be specified multiple times
+      --api-key-secret string                    (cloud-provider: hybrid) API key Kubernetes secret ('secretName:key')
+      --async-scorer                             Enable async scorer (uses io_uring on Linux)
+      --audit-log-max-files uint32               Maximum number of audit log files (1-1000)
+      --audit-log-rotation string                Audit log rotation ("daily", "hourly")
+      --audit-log-trust-forwarded-headers        Trust forwarded headers in audit logs
+      --audit-logging                            Enable audit logging
+      --cloud-provider string                    Cloud provider ID (required, see 'cloud-provider list)
+      --cloud-region string                      Cloud provider region ID (required, see 'cloud-region list --cloud-provider <provider_id>)
+      --cost-allocation-label string             Label for billing reports
+      --cpu millicores                           CPU to select a package (e.g. "1", "0.5", or "1000m")
+      --database-storage-class string            (cloud-provider: hybrid) Kubernetes storage class for database volumes
+      --db-log-level string                      Database log level ("trace", "debug", "info", "warn", "error", "off")
+      --disk bytes                               Total disk size (e.g. "200GiB"); if larger than the package's included disk, the difference is provisioned as additional storage
+      --disk-performance string                  Disk performance tier ("balanced", "cost-optimised", "performance")
+      --enable-tls                               (cloud-provider: hybrid) Enable TLS for the database service
+      --gpu millicores                           Number of GPUs to select a package (e.g. "1", "2", or "1000m")
+  -h, --help                                     help for create
+      --label stringArray                        Label ('key=value') to add/overwrite; append '-' to remove ('key-'), can be specified multiple times
+      --multi-az                                 Require a multi-AZ package
+      --name string                              Cluster name (auto-generated if not provided)
+      --node-selector stringArray                (cloud-provider: hybrid) Node selector label ('key=value'); append '-' to remove, can be specified multiple times
+      --nodes uint32                             Number of nodes (default 1)
+      --optimizer-cpu-budget int32               CPU threads for optimization (0=auto, negative=subtract from available CPUs, positive=exact count)
+      --package string                           Booking package name or ID (see 'cluster package list')
+      --pod-label stringArray                    (cloud-provider: hybrid) Pod label ('key=value'); append '-' to remove, can be specified multiple times
+      --ram bytes                                RAM to select a package (e.g. "8", "8G", "8Gi", or "8GiB")
+      --read-only-api-key-secret string          (cloud-provider: hybrid) Read-only API key Kubernetes secret ('secretName:key')
+      --rebalance-strategy string                Shard rebalance strategy ("by-count", "by-size", "by-count-and-size")
+      --replication-factor uint32                Default replication factor for new collections
+      --reserved-cpu-percentage uint32           (cloud-provider: hybrid) Percentage of CPU reserved for system components, 1-80 (default 20)
+      --reserved-memory-percentage uint32        (cloud-provider: hybrid) Percentage of memory reserved for system components, 1-80 (default 20)
+      --restart-mode string                      Restart policy ("rolling", "parallel", "automatic")
+      --service-annotation stringArray           (cloud-provider: hybrid) Service annotation ('key=value'); append '-' to remove, can be specified multiple times
+      --service-type string                      (cloud-provider: hybrid) Kubernetes service type ("cluster-ip", "node-port", "load-balancer")
+      --snapshot-storage-class string            (cloud-provider: hybrid) Kubernetes storage class for snapshot volumes
+      --tls-cert-secret string                   (cloud-provider: hybrid) TLS certificate Kubernetes secret ('secretName:key')
+      --tls-key-secret string                    (cloud-provider: hybrid) TLS private key Kubernetes secret ('secretName:key')
+      --toleration stringArray                   (cloud-provider: hybrid) Toleration ('key=value:Effect' or 'key:Exists:Effect'); use 'key-' to remove by key, can be specified multiple times
+      --topology-spread-constraint stringArray   (cloud-provider: hybrid) Topology spread constraint ('topologyKey[:maxSkew[:whenUnsatisfiable]]'); use 'topologyKey-' to remove, can be specified multiple times
+      --vectors-on-disk                          Store vectors in memmap storage for new collections
+      --version string                           Qdrant version (e.g. "v1.17.0" or "latest")
+      --volume-attributes-class string           (cloud-provider: hybrid) Kubernetes volume attributes class
+      --volume-snapshot-class string             (cloud-provider: hybrid) Kubernetes volume snapshot class
+      --wait                                     Wait for the cluster to become healthy
+      --wait-timeout duration                    Maximum time to wait for cluster health (default 10m0s)
+      --write-consistency-factor int32           Default write consistency factor for new collections
+```
+
+### Options inherited from parent commands
+
+```
+      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug               Enable debug logging to stderr
+      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                Output as JSON
+```
+
+### SEE ALSO
+
+* [qcloud cluster](qcloud_cluster.md)	 - Manage Qdrant Cloud clusters
+

--- a/docs/reference/qcloud_cluster_delete.md
+++ b/docs/reference/qcloud_cluster_delete.md
@@ -1,0 +1,41 @@
+## qcloud cluster delete
+
+Delete a cluster
+
+```
+qcloud cluster delete <cluster-id> [flags]
+```
+
+### Examples
+
+```
+# Delete a cluster (prompts for confirmation)
+qcloud cluster delete 7b2ea926-724b-4de2-b73a-8675c42a6ebe
+
+# Delete without confirmation
+qcloud cluster delete 7b2ea926-724b-4de2-b73a-8675c42a6ebe --force
+```
+
+### Options
+
+```
+  -f, --force   Skip confirmation prompt
+  -h, --help    help for delete
+```
+
+### Options inherited from parent commands
+
+```
+      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug               Enable debug logging to stderr
+      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                Output as JSON
+```
+
+### SEE ALSO
+
+* [qcloud cluster](qcloud_cluster.md)	 - Manage Qdrant Cloud clusters
+

--- a/docs/reference/qcloud_cluster_describe.md
+++ b/docs/reference/qcloud_cluster_describe.md
@@ -1,0 +1,40 @@
+## qcloud cluster describe
+
+Describe a cluster
+
+```
+qcloud cluster describe <cluster-id> [flags]
+```
+
+### Examples
+
+```
+# Describe a cluster
+qcloud cluster describe 7b2ea926-724b-4de2-b73a-8675c42a6ebe
+
+# Output as JSON
+qcloud cluster describe 7b2ea926-724b-4de2-b73a-8675c42a6ebe --json
+```
+
+### Options
+
+```
+  -h, --help   help for describe
+```
+
+### Options inherited from parent commands
+
+```
+      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug               Enable debug logging to stderr
+      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                Output as JSON
+```
+
+### SEE ALSO
+
+* [qcloud cluster](qcloud_cluster.md)	 - Manage Qdrant Cloud clusters
+

--- a/docs/reference/qcloud_cluster_key.md
+++ b/docs/reference/qcloud_cluster_key.md
@@ -1,0 +1,29 @@
+## qcloud cluster key
+
+Manage API keys for a cluster
+
+### Options
+
+```
+  -h, --help   help for key
+```
+
+### Options inherited from parent commands
+
+```
+      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug               Enable debug logging to stderr
+      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                Output as JSON
+```
+
+### SEE ALSO
+
+* [qcloud cluster](qcloud_cluster.md)	 - Manage Qdrant Cloud clusters
+* [qcloud cluster key create](qcloud_cluster_key_create.md)	 - Create an API key for a cluster
+* [qcloud cluster key delete](qcloud_cluster_key_delete.md)	 - Delete an API key from a cluster
+* [qcloud cluster key list](qcloud_cluster_key_list.md)	 - List API keys for a cluster
+

--- a/docs/reference/qcloud_cluster_key_create.md
+++ b/docs/reference/qcloud_cluster_key_create.md
@@ -1,0 +1,50 @@
+## qcloud cluster key create
+
+Create an API key for a cluster
+
+```
+qcloud cluster key create <cluster-id> [flags]
+```
+
+### Examples
+
+```
+# Create an API key
+qcloud cluster key create 7b2ea926-724b-4de2-b73a-8675c42a6ebe --name my-key
+
+# Create a read-only key with expiration
+qcloud cluster key create 7b2ea926-724b-4de2-b73a-8675c42a6ebe \
+  --name read-key --access-type read-only --expires 2025-12-31
+
+# Create a key and wait for it to become active on the cluster
+qcloud cluster key create 7b2ea926-724b-4de2-b73a-8675c42a6ebe \
+  --name my-key --wait
+```
+
+### Options
+
+```
+      --access-type string      Access type: manage or read-only (default: server assigns manage)
+      --expires string          Expiration date in YYYY-MM-DD format
+  -h, --help                    help for create
+      --name string             Name of the API key (required)
+      --wait                    Wait for the API key to become active on the cluster
+      --wait-timeout duration   Maximum time to wait for the API key to become active (default 1m0s)
+```
+
+### Options inherited from parent commands
+
+```
+      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug               Enable debug logging to stderr
+      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                Output as JSON
+```
+
+### SEE ALSO
+
+* [qcloud cluster key](qcloud_cluster_key.md)	 - Manage API keys for a cluster
+

--- a/docs/reference/qcloud_cluster_key_delete.md
+++ b/docs/reference/qcloud_cluster_key_delete.md
@@ -1,0 +1,38 @@
+## qcloud cluster key delete
+
+Delete an API key from a cluster
+
+```
+qcloud cluster key delete <cluster-id> <key-id> [flags]
+```
+
+### Examples
+
+```
+# Delete an API key
+qcloud cluster key delete 7b2ea926-724b-4de2-b73a-8675c42a6ebe a1b2c3d4-e5f6-7890-abcd-ef1234567890
+```
+
+### Options
+
+```
+  -f, --force   Skip confirmation prompt
+  -h, --help    help for delete
+```
+
+### Options inherited from parent commands
+
+```
+      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug               Enable debug logging to stderr
+      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                Output as JSON
+```
+
+### SEE ALSO
+
+* [qcloud cluster key](qcloud_cluster_key.md)	 - Manage API keys for a cluster
+

--- a/docs/reference/qcloud_cluster_key_list.md
+++ b/docs/reference/qcloud_cluster_key_list.md
@@ -1,0 +1,38 @@
+## qcloud cluster key list
+
+List API keys for a cluster
+
+```
+qcloud cluster key list <cluster-id> [flags]
+```
+
+### Examples
+
+```
+# List API keys for a cluster
+qcloud cluster key list 7b2ea926-724b-4de2-b73a-8675c42a6ebe
+```
+
+### Options
+
+```
+  -h, --help         help for list
+      --no-headers   Do not print column headers
+```
+
+### Options inherited from parent commands
+
+```
+      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug               Enable debug logging to stderr
+      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                Output as JSON
+```
+
+### SEE ALSO
+
+* [qcloud cluster key](qcloud_cluster_key.md)	 - Manage API keys for a cluster
+

--- a/docs/reference/qcloud_cluster_list.md
+++ b/docs/reference/qcloud_cluster_list.md
@@ -1,0 +1,66 @@
+## qcloud cluster list
+
+List all clusters
+
+### Synopsis
+
+List all clusters in the current account.
+
+By default, all clusters are fetched automatically across multiple pages.
+
+Use --page-size and --page-token for manual pagination:
+  --page-size limits how many clusters are returned per call.
+  --page-token resumes from a specific page (token is printed when more pages exist).
+  If --page-token is omitted, listing starts from the beginning.
+
+Use --cloud-provider and --cloud-region to filter results server-side:
+  --cloud-provider filters clusters by cloud provider ID (e.g. aws, gcp).
+  --cloud-region filters clusters by cloud provider region ID (e.g. us-east-1).
+
+```
+qcloud cluster list [flags]
+```
+
+### Examples
+
+```
+# List all clusters
+qcloud cluster list
+
+# List clusters in JSON format
+qcloud cluster list --json
+
+# Filter by cloud provider and region
+qcloud cluster list --cloud-provider aws --cloud-region eu-central-1
+
+# Manual pagination
+qcloud cluster list --page-size 10
+```
+
+### Options
+
+```
+      --cloud-provider string   Filter by cloud provider ID
+      --cloud-region string     Filter by cloud provider region ID
+  -h, --help                    help for list
+      --no-headers              Do not print column headers
+      --page-size int32         Maximum number of clusters to return per page (manual pagination mode)
+      --page-token string       Page token from a previous response to resume from (manual pagination mode)
+```
+
+### Options inherited from parent commands
+
+```
+      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug               Enable debug logging to stderr
+      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                Output as JSON
+```
+
+### SEE ALSO
+
+* [qcloud cluster](qcloud_cluster.md)	 - Manage Qdrant Cloud clusters
+

--- a/docs/reference/qcloud_cluster_logs.md
+++ b/docs/reference/qcloud_cluster_logs.md
@@ -1,0 +1,49 @@
+## qcloud cluster logs
+
+Retrieve logs for a cluster
+
+```
+qcloud cluster logs <cluster-id> [flags]
+```
+
+### Examples
+
+```
+# Get logs for a cluster
+qcloud cluster logs abc-123
+
+# Get logs since a specific date
+qcloud cluster logs abc-123 --since 2024-01-01
+
+# Get logs in a specific time range
+qcloud cluster logs abc-123 --since 2024-01-01T00:00:00Z --until 2024-01-02T00:00:00Z
+
+# Get logs in JSON format
+qcloud cluster logs abc-123 --json
+```
+
+### Options
+
+```
+  -h, --help           help for logs
+  -s, --since string   Start time for logs (RFC3339 or YYYY-MM-DD, default: 3 days ago)
+  -t, --timestamps     Prepend each log line with its timestamp
+  -u, --until string   End time for logs (RFC3339 or YYYY-MM-DD, default: now)
+```
+
+### Options inherited from parent commands
+
+```
+      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug               Enable debug logging to stderr
+      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                Output as JSON
+```
+
+### SEE ALSO
+
+* [qcloud cluster](qcloud_cluster.md)	 - Manage Qdrant Cloud clusters
+

--- a/docs/reference/qcloud_cluster_restart.md
+++ b/docs/reference/qcloud_cluster_restart.md
@@ -1,0 +1,43 @@
+## qcloud cluster restart
+
+Restart a cluster
+
+```
+qcloud cluster restart <cluster-id> [flags]
+```
+
+### Examples
+
+```
+# Restart a cluster (prompts for confirmation)
+qcloud cluster restart 7b2ea926-724b-4de2-b73a-8675c42a6ebe
+
+# Restart without confirmation and wait for healthy status
+qcloud cluster restart 7b2ea926-724b-4de2-b73a-8675c42a6ebe --force --wait
+```
+
+### Options
+
+```
+  -f, --force                   Skip confirmation prompt
+  -h, --help                    help for restart
+      --wait                    Wait for the cluster to restart to a healthy status
+      --wait-timeout duration   Maximum time to wait for cluster the cluster to restart to healthy status (default 10m0s)
+```
+
+### Options inherited from parent commands
+
+```
+      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug               Enable debug logging to stderr
+      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                Output as JSON
+```
+
+### SEE ALSO
+
+* [qcloud cluster](qcloud_cluster.md)	 - Manage Qdrant Cloud clusters
+

--- a/docs/reference/qcloud_cluster_scale.md
+++ b/docs/reference/qcloud_cluster_scale.md
@@ -1,0 +1,71 @@
+## qcloud cluster scale
+
+Scales the resources of a cluster
+
+### Synopsis
+
+Scales the resources of a cluster.
+
+Use this command to change the resource package for the nodes of a Qdrant cluster, change
+the number of nodes in the cluster, and allocate more disk space per node. You can select
+one of the pre-defined resource packages to apply for all nodes in the cluster. A package
+defines CPU, RAM, GPU, and minimum disk size.
+
+The --cpu, --ram, and --gpu flags specify per-node resources and are used to match a
+package. If none of these flags are provided, the current package is preserved. Available
+packages can be listed with 'package list' using the --cloud-provider and
+--cloud-region flags.
+
+Each package includes a baseline disk size. Requesting more disk than the baseline with
+--disk provisions the difference as additional storage. Disk cannot be downscaled. If a
+new package has a larger baseline disk than the current total, the disk size increases to
+match.
+
+```
+qcloud cluster scale <cluster-id> [flags]
+```
+
+### Examples
+
+```
+# Scale up CPU and RAM
+qcloud cluster scale 7b2ea926-724b-4de2-b73a-8675c42a6ebe --cpu 4 --ram 16Gi
+
+# Add more nodes
+qcloud cluster scale 7b2ea926-724b-4de2-b73a-8675c42a6ebe --nodes 3
+
+# Increase disk and wait for completion
+qcloud cluster scale 7b2ea926-724b-4de2-b73a-8675c42a6ebe --disk 500Gi --wait
+```
+
+### Options
+
+```
+      --cpu millicores            CPU per node (e.g. "1", "0.5", or "1000m")
+      --disk bytes                Total disk size per node (e.g. "200GiB"); if larger than the node's included disk, the difference is provisioned as additional storage
+      --disk-performance string   Disk performance tier ("balanced", "cost-optimised", "performance")
+  -f, --force                     Skip confirmation prompts
+      --gpu millicores            Number of GPUs per node (e.g. "1", "2", or "1000m")
+  -h, --help                      help for scale
+      --nodes uint32              Number of nodes
+      --ram bytes                 RAM per node (e.g. "8", "8G", "8Gi", or "8GiB")
+      --wait                      Wait for the cluster to become healthy
+      --wait-timeout duration     Maximum time to wait for cluster health (default 10m0s)
+```
+
+### Options inherited from parent commands
+
+```
+      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug               Enable debug logging to stderr
+      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                Output as JSON
+```
+
+### SEE ALSO
+
+* [qcloud cluster](qcloud_cluster.md)	 - Manage Qdrant Cloud clusters
+

--- a/docs/reference/qcloud_cluster_suspend.md
+++ b/docs/reference/qcloud_cluster_suspend.md
@@ -1,0 +1,38 @@
+## qcloud cluster suspend
+
+Suspend a cluster
+
+```
+qcloud cluster suspend <cluster-id> [flags]
+```
+
+### Examples
+
+```
+# Suspend a cluster
+qcloud cluster suspend 7b2ea926-724b-4de2-b73a-8675c42a6ebe --force
+```
+
+### Options
+
+```
+  -f, --force   Skip confirmation prompt
+  -h, --help    help for suspend
+```
+
+### Options inherited from parent commands
+
+```
+      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug               Enable debug logging to stderr
+      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                Output as JSON
+```
+
+### SEE ALSO
+
+* [qcloud cluster](qcloud_cluster.md)	 - Manage Qdrant Cloud clusters
+

--- a/docs/reference/qcloud_cluster_unsuspend.md
+++ b/docs/reference/qcloud_cluster_unsuspend.md
@@ -1,0 +1,37 @@
+## qcloud cluster unsuspend
+
+Unsuspend a cluster
+
+```
+qcloud cluster unsuspend <cluster-id> [flags]
+```
+
+### Examples
+
+```
+# Unsuspend a cluster
+qcloud cluster unsuspend 7b2ea926-724b-4de2-b73a-8675c42a6ebe
+```
+
+### Options
+
+```
+  -h, --help   help for unsuspend
+```
+
+### Options inherited from parent commands
+
+```
+      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug               Enable debug logging to stderr
+      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                Output as JSON
+```
+
+### SEE ALSO
+
+* [qcloud cluster](qcloud_cluster.md)	 - Manage Qdrant Cloud clusters
+

--- a/docs/reference/qcloud_cluster_update.md
+++ b/docs/reference/qcloud_cluster_update.md
@@ -1,0 +1,139 @@
+## qcloud cluster update
+
+Update an existing cluster
+
+### Synopsis
+
+Updates the configuration of a cluster.
+
+Use this command to modify cluster settings such as the Qdrant version, labels,
+database defaults, IP restrictions, restart mode, rebalance strategy, and hybrid
+cluster configuration.
+
+Version upgrades (--version) will trigger a rolling restart of the cluster.
+
+Database configuration changes (--replication-factor, --write-consistency-factor,
+--async-scorer, --optimizer-cpu-budget, --vectors-on-disk, --db-log-level,
+--audit-logging and related flags, --enable-tls, --api-key-secret,
+--read-only-api-key-secret, --tls-cert-secret, --tls-key-secret) will trigger a
+rolling restart of the cluster. The cluster remains available during the restart,
+but individual nodes will be briefly unavailable as they cycle.
+
+Hybrid cluster configuration changes (--service-type, --node-selector,
+--toleration, --topology-spread-constraint, --annotation, --pod-label,
+--service-annotation, --reserved-cpu-percentage, --reserved-memory-percentage,
+and storage class flags) will also trigger a rolling restart.
+
+Cluster configuration changes (--allowed-ip, --restart-mode, --rebalance-strategy,
+--disk-performance, --cost-allocation-label) and label changes take effect without
+a restart.
+
+Labels are merged with existing labels by default. Use 'key=value' to add or
+overwrite a label, and 'key-' (with a trailing dash) to remove one.
+
+Allowed IPs are merged with existing IPs by default. Specify an IP CIDR to add
+it, or append '-' (e.g. '10.0.0.0/8-') to remove one.
+
+Node selectors, annotations, pod labels, and service annotations support the same
+'key=value' / 'key-' merge syntax as labels.
+
+Tolerations are merged with existing tolerations. Use 'key-' to remove all
+tolerations matching that key.
+
+Topology spread constraints are merged by topologyKey. Use 'topologyKey-' to
+remove a constraint.
+
+```
+qcloud cluster update <cluster-id> [flags]
+```
+
+### Examples
+
+```
+# Add a label to a cluster
+qcloud cluster update 7b2ea926-724b-4de2-b73a-8675c42a6ebe --label env=staging
+
+# Remove a label
+qcloud cluster update 7b2ea926-724b-4de2-b73a-8675c42a6ebe --label env-
+
+# Restrict access to specific IPs
+qcloud cluster update 7b2ea926-724b-4de2-b73a-8675c42a6ebe --allowed-ip 10.0.0.0/8
+
+# Upgrade the Qdrant version
+qcloud cluster update 7b2ea926-724b-4de2-b73a-8675c42a6ebe --version v1.17.0
+
+# Change replication factor (triggers rolling restart)
+qcloud cluster update 7b2ea926-724b-4de2-b73a-8675c42a6ebe --replication-factor 3 --force
+
+# Set service type to load balancer (hybrid only, triggers rolling restart)
+qcloud cluster update 7b2ea926-724b-4de2-b73a-8675c42a6ebe --service-type load-balancer
+
+# Add a node selector and toleration (hybrid only, triggers rolling restart)
+qcloud cluster update 7b2ea926-724b-4de2-b73a-8675c42a6ebe \
+  --node-selector disktype=ssd --toleration "dedicated=qdrant:NoSchedule"
+
+# Remove a node selector (hybrid only)
+qcloud cluster update 7b2ea926-724b-4de2-b73a-8675c42a6ebe --node-selector disktype-
+
+# Change database storage class (hybrid only, triggers rolling restart)
+qcloud cluster update 7b2ea926-724b-4de2-b73a-8675c42a6ebe --database-storage-class fast-ssd
+```
+
+### Options
+
+```
+      --allowed-ip stringArray                   Allowed client IP CIDR range (e.g. "10.0.0.0/8"); append '-' to remove; max 20
+      --annotation stringArray                   (cloud-provider: hybrid) Pod annotation ('key=value'); append '-' to remove, can be specified multiple times
+      --api-key-secret string                    (cloud-provider: hybrid) API key Kubernetes secret ('secretName:key')
+      --async-scorer                             Enable async scorer (uses io_uring on Linux)
+      --audit-log-max-files uint32               Maximum number of audit log files (1-1000)
+      --audit-log-rotation string                Audit log rotation ("daily", "hourly")
+      --audit-log-trust-forwarded-headers        Trust forwarded headers in audit logs
+      --audit-logging                            Enable audit logging
+      --cost-allocation-label string             Label for billing reports
+      --database-storage-class string            (cloud-provider: hybrid) Kubernetes storage class for database volumes
+      --db-log-level string                      Database log level ("trace", "debug", "info", "warn", "error", "off")
+      --disk-performance string                  Disk performance tier ("balanced", "cost-optimised", "performance")
+      --enable-tls                               (cloud-provider: hybrid) Enable TLS for the database service
+  -f, --force                                    Skip confirmation prompt
+  -h, --help                                     help for update
+      --label stringArray                        Label ('key=value') to add/overwrite; append '-' to remove ('key-'), can be specified multiple times
+      --node-selector stringArray                (cloud-provider: hybrid) Node selector label ('key=value'); append '-' to remove, can be specified multiple times
+      --optimizer-cpu-budget int32               CPU threads for optimization (0=auto, negative=subtract from available CPUs, positive=exact count)
+      --pod-label stringArray                    (cloud-provider: hybrid) Pod label ('key=value'); append '-' to remove, can be specified multiple times
+      --read-only-api-key-secret string          (cloud-provider: hybrid) Read-only API key Kubernetes secret ('secretName:key')
+      --rebalance-strategy string                Shard rebalance strategy ("by-count", "by-size", "by-count-and-size")
+      --replication-factor uint32                Default replication factor for new collections
+      --reserved-cpu-percentage uint32           (cloud-provider: hybrid) Percentage of CPU reserved for system components, 1-80 (default 20)
+      --reserved-memory-percentage uint32        (cloud-provider: hybrid) Percentage of memory reserved for system components, 1-80 (default 20)
+      --restart-mode string                      Restart policy ("rolling", "parallel", "automatic")
+      --service-annotation stringArray           (cloud-provider: hybrid) Service annotation ('key=value'); append '-' to remove, can be specified multiple times
+      --service-type string                      (cloud-provider: hybrid) Kubernetes service type ("cluster-ip", "node-port", "load-balancer")
+      --snapshot-storage-class string            (cloud-provider: hybrid) Kubernetes storage class for snapshot volumes
+      --tls-cert-secret string                   (cloud-provider: hybrid) TLS certificate Kubernetes secret ('secretName:key')
+      --tls-key-secret string                    (cloud-provider: hybrid) TLS private key Kubernetes secret ('secretName:key')
+      --toleration stringArray                   (cloud-provider: hybrid) Toleration ('key=value:Effect' or 'key:Exists:Effect'); use 'key-' to remove by key, can be specified multiple times
+      --topology-spread-constraint stringArray   (cloud-provider: hybrid) Topology spread constraint ('topologyKey[:maxSkew[:whenUnsatisfiable]]'); use 'topologyKey-' to remove, can be specified multiple times
+      --vectors-on-disk                          Store vectors in memmap storage for new collections
+      --version string                           Qdrant version (e.g. "v1.17.0" or "latest")
+      --volume-attributes-class string           (cloud-provider: hybrid) Kubernetes volume attributes class
+      --volume-snapshot-class string             (cloud-provider: hybrid) Kubernetes volume snapshot class
+      --write-consistency-factor int32           Default write consistency factor for new collections
+```
+
+### Options inherited from parent commands
+
+```
+      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug               Enable debug logging to stderr
+      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                Output as JSON
+```
+
+### SEE ALSO
+
+* [qcloud cluster](qcloud_cluster.md)	 - Manage Qdrant Cloud clusters
+

--- a/docs/reference/qcloud_cluster_version.md
+++ b/docs/reference/qcloud_cluster_version.md
@@ -1,0 +1,27 @@
+## qcloud cluster version
+
+Manage Qdrant versions
+
+### Options
+
+```
+  -h, --help   help for version
+```
+
+### Options inherited from parent commands
+
+```
+      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug               Enable debug logging to stderr
+      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                Output as JSON
+```
+
+### SEE ALSO
+
+* [qcloud cluster](qcloud_cluster.md)	 - Manage Qdrant Cloud clusters
+* [qcloud cluster version list](qcloud_cluster_version_list.md)	 - List available Qdrant versions
+

--- a/docs/reference/qcloud_cluster_version_list.md
+++ b/docs/reference/qcloud_cluster_version_list.md
@@ -1,0 +1,38 @@
+## qcloud cluster version list
+
+List available Qdrant versions
+
+```
+qcloud cluster version list [flags]
+```
+
+### Examples
+
+```
+# List available Qdrant versions
+qcloud cluster version list
+```
+
+### Options
+
+```
+  -h, --help         help for list
+      --no-headers   Do not print column headers
+```
+
+### Options inherited from parent commands
+
+```
+      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug               Enable debug logging to stderr
+      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                Output as JSON
+```
+
+### SEE ALSO
+
+* [qcloud cluster version](qcloud_cluster_version.md)	 - Manage Qdrant versions
+

--- a/docs/reference/qcloud_cluster_wait.md
+++ b/docs/reference/qcloud_cluster_wait.md
@@ -1,0 +1,41 @@
+## qcloud cluster wait
+
+Wait for a cluster to become healthy
+
+```
+qcloud cluster wait <cluster-id> [flags]
+```
+
+### Examples
+
+```
+# Wait for a cluster to become healthy
+qcloud cluster wait 7b2ea926-724b-4de2-b73a-8675c42a6ebe
+
+# Wait with a custom timeout
+qcloud cluster wait 7b2ea926-724b-4de2-b73a-8675c42a6ebe --timeout 30m
+```
+
+### Options
+
+```
+  -h, --help               help for wait
+      --timeout duration   Maximum time to wait for the cluster to become healthy (default 10m0s)
+```
+
+### Options inherited from parent commands
+
+```
+      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug               Enable debug logging to stderr
+      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                Output as JSON
+```
+
+### SEE ALSO
+
+* [qcloud cluster](qcloud_cluster.md)	 - Manage Qdrant Cloud clusters
+

--- a/docs/reference/qcloud_context.md
+++ b/docs/reference/qcloud_context.md
@@ -1,0 +1,31 @@
+## qcloud context
+
+Manage named configuration contexts
+
+### Options
+
+```
+  -h, --help   help for context
+```
+
+### Options inherited from parent commands
+
+```
+      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug               Enable debug logging to stderr
+      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                Output as JSON
+```
+
+### SEE ALSO
+
+* [qcloud](qcloud.md)	 - Qdrant Cloud CLI
+* [qcloud context delete](qcloud_context_delete.md)	 - Delete a context
+* [qcloud context list](qcloud_context_list.md)	 - List all contexts
+* [qcloud context set](qcloud_context_set.md)	 - Create or update a context
+* [qcloud context show](qcloud_context_show.md)	 - Show the active context configuration
+* [qcloud context use](qcloud_context_use.md)	 - Set the active context
+

--- a/docs/reference/qcloud_context_delete.md
+++ b/docs/reference/qcloud_context_delete.md
@@ -1,0 +1,41 @@
+## qcloud context delete
+
+Delete a context
+
+```
+qcloud context delete <name> [flags]
+```
+
+### Examples
+
+```
+# Delete a context
+qcloud context delete staging
+
+# Delete without confirmation
+qcloud context delete staging --force
+```
+
+### Options
+
+```
+  -f, --force   Skip confirmation prompt
+  -h, --help    help for delete
+```
+
+### Options inherited from parent commands
+
+```
+      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug               Enable debug logging to stderr
+      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                Output as JSON
+```
+
+### SEE ALSO
+
+* [qcloud context](qcloud_context.md)	 - Manage named configuration contexts
+

--- a/docs/reference/qcloud_context_list.md
+++ b/docs/reference/qcloud_context_list.md
@@ -1,0 +1,37 @@
+## qcloud context list
+
+List all contexts
+
+```
+qcloud context list [flags]
+```
+
+### Examples
+
+```
+# List all contexts
+qcloud context list
+```
+
+### Options
+
+```
+  -h, --help   help for list
+```
+
+### Options inherited from parent commands
+
+```
+      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug               Enable debug logging to stderr
+      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                Output as JSON
+```
+
+### SEE ALSO
+
+* [qcloud context](qcloud_context.md)	 - Manage named configuration contexts
+

--- a/docs/reference/qcloud_context_set.md
+++ b/docs/reference/qcloud_context_set.md
@@ -1,0 +1,78 @@
+## qcloud context set
+
+Create or update a context
+
+### Synopsis
+
+Create or update a named context in the configuration file.
+
+A context stores connection settings (endpoint, account ID) and API key
+credentials under a name, so you can switch between environments with
+"qcloud context use <name>".
+
+There are three ways to provide the API key:
+
+  --api-key              Store the key directly in the config file (plaintext).
+  --api-key-command      Store a shell command that is executed at runtime to
+                         retrieve the key. The command is run via "sh -c" and
+                         its stdout is used as the API key. This avoids storing
+                         secrets in plaintext.
+  --api-key-helper       Use a named preset that generates the command for you.
+                         Must be paired with --api-key-ref.
+
+Supported helpers and the commands they generate:
+
+  1password    op read <ref>
+  vault        vault kv get -field=api_key <ref>
+  pass         pass show <ref>
+  keychain     security find-generic-password -s <ref> -w
+
+When an api_key_command is set, any existing plaintext api_key is removed from
+the context. Flags and environment variables (--api-key, QDRANT_CLOUD_API_KEY)
+still take precedence over the command at runtime.
+
+```
+qcloud context set <name> [flags]
+```
+
+### Examples
+
+```
+# Save the current configuration as a named context
+qcloud context set production
+
+# Create a context with explicit values
+qcloud context set staging --api-key sk-... --account-id acc-123
+
+# Use an external command to resolve the API key
+qcloud context set staging --api-key-command 'op read op://vault/qdrant/api-key' --account-id acc-123
+
+# Use a named helper preset
+qcloud context set staging --api-key-helper 1password --api-key-ref op://vault/qdrant/api-key --account-id acc-123
+```
+
+### Options
+
+```
+      --account-id string        Account ID for this context
+      --api-key string           API key for this context
+      --api-key-command string   Shell command that outputs the API key (e.g. 'op read op://vault/qdrant/api-key')
+      --api-key-helper string    Named credential helper (1password, vault, pass, keychain)
+      --api-key-ref string       Secret reference for the credential helper
+      --endpoint string          API endpoint for this context
+  -h, --help                     help for set
+```
+
+### Options inherited from parent commands
+
+```
+  -c, --config string    Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --context string   Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug            Enable debug logging to stderr
+      --json             Output as JSON
+```
+
+### SEE ALSO
+
+* [qcloud context](qcloud_context.md)	 - Manage named configuration contexts
+

--- a/docs/reference/qcloud_context_show.md
+++ b/docs/reference/qcloud_context_show.md
@@ -1,0 +1,37 @@
+## qcloud context show
+
+Show the active context configuration
+
+```
+qcloud context show [flags]
+```
+
+### Examples
+
+```
+# Show the active context
+qcloud context show
+```
+
+### Options
+
+```
+  -h, --help   help for show
+```
+
+### Options inherited from parent commands
+
+```
+      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug               Enable debug logging to stderr
+      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                Output as JSON
+```
+
+### SEE ALSO
+
+* [qcloud context](qcloud_context.md)	 - Manage named configuration contexts
+

--- a/docs/reference/qcloud_context_use.md
+++ b/docs/reference/qcloud_context_use.md
@@ -1,0 +1,37 @@
+## qcloud context use
+
+Set the active context
+
+```
+qcloud context use <name> [flags]
+```
+
+### Examples
+
+```
+# Switch to another context
+qcloud context use production
+```
+
+### Options
+
+```
+  -h, --help   help for use
+```
+
+### Options inherited from parent commands
+
+```
+      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug               Enable debug logging to stderr
+      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                Output as JSON
+```
+
+### SEE ALSO
+
+* [qcloud context](qcloud_context.md)	 - Manage named configuration contexts
+

--- a/docs/reference/qcloud_hybrid.md
+++ b/docs/reference/qcloud_hybrid.md
@@ -1,0 +1,32 @@
+## qcloud hybrid
+
+Manage hybrid cloud environments
+
+### Options
+
+```
+  -h, --help   help for hybrid
+```
+
+### Options inherited from parent commands
+
+```
+      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug               Enable debug logging to stderr
+      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                Output as JSON
+```
+
+### SEE ALSO
+
+* [qcloud](qcloud.md)	 - Qdrant Cloud CLI
+* [qcloud hybrid bootstrap](qcloud_hybrid_bootstrap.md)	 - Generate bootstrap commands for a hybrid cloud environment
+* [qcloud hybrid create](qcloud_hybrid_create.md)	 - Create a new hybrid cloud environment
+* [qcloud hybrid delete](qcloud_hybrid_delete.md)	 - Delete a hybrid cloud environment
+* [qcloud hybrid describe](qcloud_hybrid_describe.md)	 - Describe a hybrid cloud environment
+* [qcloud hybrid list](qcloud_hybrid_list.md)	 - List all hybrid cloud environments
+* [qcloud hybrid update](qcloud_hybrid_update.md)	 - Update a hybrid cloud environment
+

--- a/docs/reference/qcloud_hybrid_bootstrap.md
+++ b/docs/reference/qcloud_hybrid_bootstrap.md
@@ -1,0 +1,50 @@
+## qcloud hybrid bootstrap
+
+Generate bootstrap commands for a hybrid cloud environment
+
+### Synopsis
+
+Generate the commands needed to bootstrap a Kubernetes cluster into a hybrid cloud environment.
+
+Each command in the output is ready to copy-paste or pipe to a shell. The credentials
+printed to stderr are sensitive and should be treated as secrets.
+
+Note: each invocation creates new Qdrant Cloud access tokens and registry credentials.
+Only run this if the Kubernetes cluster is not yet registered to the environment.
+
+```
+qcloud hybrid bootstrap <env-id> [flags]
+```
+
+### Examples
+
+```
+# Generate bootstrap commands for an environment
+qcloud hybrid bootstrap 7b2ea926-724b-4de2-b73a-8675c42a6ebe
+
+# Pipe directly to a shell
+qcloud hybrid bootstrap 7b2ea926-724b-4de2-b73a-8675c42a6ebe | bash
+```
+
+### Options
+
+```
+  -h, --help   help for bootstrap
+```
+
+### Options inherited from parent commands
+
+```
+      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug               Enable debug logging to stderr
+      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                Output as JSON
+```
+
+### SEE ALSO
+
+* [qcloud hybrid](qcloud_hybrid.md)	 - Manage hybrid cloud environments
+

--- a/docs/reference/qcloud_hybrid_create.md
+++ b/docs/reference/qcloud_hybrid_create.md
@@ -1,0 +1,58 @@
+## qcloud hybrid create
+
+Create a new hybrid cloud environment
+
+### Synopsis
+
+Create a new Hybrid Cloud Environment to deploy and manage Qdrant on your own
+Kubernetes clusters (on-premises, cloud, or edge) with enterprise-grade
+reliability.
+
+Hybrid Cloud access must be enabled for your account by the Qdrant sales team.
+If your account does not have access, you will be prompted to contact us.
+
+```
+qcloud hybrid create [flags]
+```
+
+### Examples
+
+```
+# Create a hybrid cloud environment
+qcloud hybrid create --name my-hybrid-env
+
+# Create with a custom namespace
+qcloud hybrid create --name my-hybrid-env --namespace qdrant-hybrid
+
+# Create with storage classes
+qcloud hybrid create --name my-hybrid-env \
+  --database-storage-class premium-rwo --snapshot-storage-class standard
+```
+
+### Options
+
+```
+      --database-storage-class string   Default database storage class (uses cluster default if omitted)
+  -h, --help                            help for create
+      --log-level string                Log level for deployed components ("debug", "info", "warn", "error")
+      --name string                     Name of the hybrid cloud environment (required)
+      --namespace string                Kubernetes namespace where Qdrant components are deployed (read-only after bootstrapping)
+      --snapshot-storage-class string   Default snapshot storage class (uses cluster default if omitted)
+```
+
+### Options inherited from parent commands
+
+```
+      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug               Enable debug logging to stderr
+      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                Output as JSON
+```
+
+### SEE ALSO
+
+* [qcloud hybrid](qcloud_hybrid.md)	 - Manage hybrid cloud environments
+

--- a/docs/reference/qcloud_hybrid_delete.md
+++ b/docs/reference/qcloud_hybrid_delete.md
@@ -1,0 +1,41 @@
+## qcloud hybrid delete
+
+Delete a hybrid cloud environment
+
+```
+qcloud hybrid delete <env-id> [flags]
+```
+
+### Examples
+
+```
+# Delete a hybrid cloud environment (prompts for confirmation)
+qcloud hybrid delete 7b2ea926-724b-4de2-b73a-8675c42a6ebe
+
+# Delete without confirmation
+qcloud hybrid delete 7b2ea926-724b-4de2-b73a-8675c42a6ebe --force
+```
+
+### Options
+
+```
+  -f, --force   Skip confirmation prompt
+  -h, --help    help for delete
+```
+
+### Options inherited from parent commands
+
+```
+      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug               Enable debug logging to stderr
+      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                Output as JSON
+```
+
+### SEE ALSO
+
+* [qcloud hybrid](qcloud_hybrid.md)	 - Manage hybrid cloud environments
+

--- a/docs/reference/qcloud_hybrid_describe.md
+++ b/docs/reference/qcloud_hybrid_describe.md
@@ -1,0 +1,30 @@
+## qcloud hybrid describe
+
+Describe a hybrid cloud environment
+
+```
+qcloud hybrid describe <env-id> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for describe
+```
+
+### Options inherited from parent commands
+
+```
+      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug               Enable debug logging to stderr
+      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                Output as JSON
+```
+
+### SEE ALSO
+
+* [qcloud hybrid](qcloud_hybrid.md)	 - Manage hybrid cloud environments
+

--- a/docs/reference/qcloud_hybrid_list.md
+++ b/docs/reference/qcloud_hybrid_list.md
@@ -1,0 +1,31 @@
+## qcloud hybrid list
+
+List all hybrid cloud environments
+
+```
+qcloud hybrid list [flags]
+```
+
+### Options
+
+```
+  -h, --help         help for list
+      --no-headers   Do not print column headers
+```
+
+### Options inherited from parent commands
+
+```
+      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug               Enable debug logging to stderr
+      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                Output as JSON
+```
+
+### SEE ALSO
+
+* [qcloud hybrid](qcloud_hybrid.md)	 - Manage hybrid cloud environments
+

--- a/docs/reference/qcloud_hybrid_update.md
+++ b/docs/reference/qcloud_hybrid_update.md
@@ -1,0 +1,49 @@
+## qcloud hybrid update
+
+Update a hybrid cloud environment
+
+```
+qcloud hybrid update <env-id> [flags]
+```
+
+### Examples
+
+```
+# Rename a hybrid cloud environment
+qcloud hybrid update 7b2ea926-724b-4de2-b73a-8675c42a6ebe --name new-name
+
+# Update the default storage classes
+qcloud hybrid update 7b2ea926-724b-4de2-b73a-8675c42a6ebe \
+  --database-storage-class premium-rwo --snapshot-storage-class standard
+
+# Change the log level
+qcloud hybrid update 7b2ea926-724b-4de2-b73a-8675c42a6ebe --log-level debug
+```
+
+### Options
+
+```
+      --database-storage-class string   Default database storage class (uses cluster default if omitted)
+  -h, --help                            help for update
+      --log-level string                Log level for deployed components ("debug", "info", "warn", "error")
+      --name string                     New name for the hybrid cloud environment
+      --namespace string                Kubernetes namespace where Qdrant components are deployed (read-only after bootstrapping)
+      --snapshot-storage-class string   Default snapshot storage class (uses cluster default if omitted)
+```
+
+### Options inherited from parent commands
+
+```
+      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug               Enable debug logging to stderr
+      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                Output as JSON
+```
+
+### SEE ALSO
+
+* [qcloud hybrid](qcloud_hybrid.md)	 - Manage hybrid cloud environments
+

--- a/docs/reference/qcloud_iam.md
+++ b/docs/reference/qcloud_iam.md
@@ -1,0 +1,34 @@
+## qcloud iam
+
+Manage IAM resources in Qdrant Cloud
+
+### Synopsis
+
+Manage IAM resources for the Qdrant Cloud account.
+
+### Options
+
+```
+  -h, --help   help for iam
+```
+
+### Options inherited from parent commands
+
+```
+      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug               Enable debug logging to stderr
+      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                Output as JSON
+```
+
+### SEE ALSO
+
+* [qcloud](qcloud.md)	 - Qdrant Cloud CLI
+* [qcloud iam key](qcloud_iam_key.md)	 - Manage cloud management keys
+* [qcloud iam permission](qcloud_iam_permission.md)	 - Manage permissions in Qdrant Cloud
+* [qcloud iam role](qcloud_iam_role.md)	 - Manage roles in Qdrant Cloud
+* [qcloud iam user](qcloud_iam_user.md)	 - Manage users in Qdrant Cloud
+

--- a/docs/reference/qcloud_iam_key.md
+++ b/docs/reference/qcloud_iam_key.md
@@ -1,0 +1,36 @@
+## qcloud iam key
+
+Manage cloud management keys
+
+### Synopsis
+
+Manage cloud management keys for the account.
+
+Management keys authenticate requests to the Qdrant Cloud API. Use them to authorize
+the CLI, automation scripts, or any other tooling that calls the Qdrant Cloud API.
+
+### Options
+
+```
+  -h, --help   help for key
+```
+
+### Options inherited from parent commands
+
+```
+      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug               Enable debug logging to stderr
+      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                Output as JSON
+```
+
+### SEE ALSO
+
+* [qcloud iam](qcloud_iam.md)	 - Manage IAM resources in Qdrant Cloud
+* [qcloud iam key create](qcloud_iam_key_create.md)	 - Create a cloud management key
+* [qcloud iam key delete](qcloud_iam_key_delete.md)	 - Delete a cloud management key
+* [qcloud iam key list](qcloud_iam_key_list.md)	 - List cloud management keys
+

--- a/docs/reference/qcloud_iam_key_create.md
+++ b/docs/reference/qcloud_iam_key_create.md
@@ -1,0 +1,48 @@
+## qcloud iam key create
+
+Create a cloud management key
+
+### Synopsis
+
+Create a new cloud management key for the account.
+
+Management keys grant access to the Qdrant Cloud API. The full key value is returned
+only once at creation time — store it securely, as it cannot be retrieved again. If a
+key is lost, delete it and create a new one.
+
+```
+qcloud iam key create [flags]
+```
+
+### Examples
+
+```
+# Create a new management key
+qcloud iam key create
+
+# Create and capture the key value in a script
+qcloud iam key create --json | jq -r '.key'
+```
+
+### Options
+
+```
+  -h, --help   help for create
+```
+
+### Options inherited from parent commands
+
+```
+      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug               Enable debug logging to stderr
+      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                Output as JSON
+```
+
+### SEE ALSO
+
+* [qcloud iam key](qcloud_iam_key.md)	 - Manage cloud management keys
+

--- a/docs/reference/qcloud_iam_key_delete.md
+++ b/docs/reference/qcloud_iam_key_delete.md
@@ -1,0 +1,50 @@
+## qcloud iam key delete
+
+Delete a cloud management key
+
+### Synopsis
+
+Delete a cloud management key from the account.
+
+Deleting a key immediately revokes its access to the Qdrant Cloud API. Any client
+using the deleted key will receive authentication errors. This action cannot be undone.
+
+A confirmation prompt is shown unless --force is passed.
+
+```
+qcloud iam key delete <key-id> [flags]
+```
+
+### Examples
+
+```
+# Delete a management key (with confirmation prompt)
+qcloud iam key delete a1b2c3d4-e5f6-7890-abcd-ef1234567890
+
+# Delete without confirmation
+qcloud iam key delete a1b2c3d4-e5f6-7890-abcd-ef1234567890 --force
+```
+
+### Options
+
+```
+  -f, --force   Skip confirmation prompt
+  -h, --help    help for delete
+```
+
+### Options inherited from parent commands
+
+```
+      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug               Enable debug logging to stderr
+      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                Output as JSON
+```
+
+### SEE ALSO
+
+* [qcloud iam key](qcloud_iam_key.md)	 - Manage cloud management keys
+

--- a/docs/reference/qcloud_iam_key_list.md
+++ b/docs/reference/qcloud_iam_key_list.md
@@ -1,0 +1,49 @@
+## qcloud iam key list
+
+List cloud management keys
+
+### Synopsis
+
+List all cloud management keys for the account.
+
+Management keys grant access to the Qdrant Cloud API and are used to authenticate CLI
+and API requests. Each key is identified by its ID and a prefix — the prefix represents
+the first bytes of the key value and is safe to display.
+
+```
+qcloud iam key list [flags]
+```
+
+### Examples
+
+```
+# List all management keys for the account
+qcloud iam key list
+
+# Output as JSON
+qcloud iam key list --json
+```
+
+### Options
+
+```
+  -h, --help         help for list
+      --no-headers   Do not print column headers
+```
+
+### Options inherited from parent commands
+
+```
+      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug               Enable debug logging to stderr
+      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                Output as JSON
+```
+
+### SEE ALSO
+
+* [qcloud iam key](qcloud_iam_key.md)	 - Manage cloud management keys
+

--- a/docs/reference/qcloud_iam_permission.md
+++ b/docs/reference/qcloud_iam_permission.md
@@ -1,0 +1,34 @@
+## qcloud iam permission
+
+Manage permissions in Qdrant Cloud
+
+### Synopsis
+
+Manage permissions for the Qdrant Cloud account.
+
+Permissions represent individual access rights that can be assigned to roles.
+Use these commands to discover which permissions are available in the system.
+
+### Options
+
+```
+  -h, --help   help for permission
+```
+
+### Options inherited from parent commands
+
+```
+      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug               Enable debug logging to stderr
+      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                Output as JSON
+```
+
+### SEE ALSO
+
+* [qcloud iam](qcloud_iam.md)	 - Manage IAM resources in Qdrant Cloud
+* [qcloud iam permission list](qcloud_iam_permission_list.md)	 - List all available permissions
+

--- a/docs/reference/qcloud_iam_permission_list.md
+++ b/docs/reference/qcloud_iam_permission_list.md
@@ -1,0 +1,49 @@
+## qcloud iam permission list
+
+List all available permissions
+
+### Synopsis
+
+List all permissions known in the system for the account.
+
+Permissions are the individual access rights that can be assigned to roles.
+Each permission has a value (e.g. "read:clusters") and a category
+(e.g. "Cluster").
+
+```
+qcloud iam permission list [flags]
+```
+
+### Examples
+
+```
+# List all available permissions
+qcloud iam permission list
+
+# Output as JSON
+qcloud iam permission list --json
+```
+
+### Options
+
+```
+  -h, --help         help for list
+      --no-headers   Do not print column headers
+```
+
+### Options inherited from parent commands
+
+```
+      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug               Enable debug logging to stderr
+      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                Output as JSON
+```
+
+### SEE ALSO
+
+* [qcloud iam permission](qcloud_iam_permission.md)	 - Manage permissions in Qdrant Cloud
+

--- a/docs/reference/qcloud_iam_role.md
+++ b/docs/reference/qcloud_iam_role.md
@@ -1,0 +1,42 @@
+## qcloud iam role
+
+Manage roles in Qdrant Cloud
+
+### Synopsis
+
+Manage roles for the Qdrant Cloud account.
+
+Roles define sets of permissions that control access to resources. There are two
+types of roles: system roles (immutable, managed by Qdrant) and custom roles
+(created and managed by the account). Use these commands to list, inspect, create,
+update, and delete custom roles, as well as manage their permissions.
+
+### Options
+
+```
+  -h, --help   help for role
+```
+
+### Options inherited from parent commands
+
+```
+      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug               Enable debug logging to stderr
+      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                Output as JSON
+```
+
+### SEE ALSO
+
+* [qcloud iam](qcloud_iam.md)	 - Manage IAM resources in Qdrant Cloud
+* [qcloud iam role assign-permission](qcloud_iam_role_assign-permission.md)	 - Add permissions to a role
+* [qcloud iam role create](qcloud_iam_role_create.md)	 - Create a custom role
+* [qcloud iam role delete](qcloud_iam_role_delete.md)	 - Delete a custom role
+* [qcloud iam role describe](qcloud_iam_role_describe.md)	 - Describe a role
+* [qcloud iam role list](qcloud_iam_role_list.md)	 - List all roles
+* [qcloud iam role remove-permission](qcloud_iam_role_remove-permission.md)	 - Remove permissions from a role
+* [qcloud iam role update](qcloud_iam_role_update.md)	 - Update a custom role
+

--- a/docs/reference/qcloud_iam_role_assign-permission.md
+++ b/docs/reference/qcloud_iam_role_assign-permission.md
@@ -1,0 +1,50 @@
+## qcloud iam role assign-permission
+
+Add permissions to a role
+
+### Synopsis
+
+Add permissions to a custom role.
+
+Fetches the role's current permissions, merges the new ones (deduplicating),
+and updates the role. Use "qcloud iam permission list" to see available
+permissions.
+
+```
+qcloud iam role assign-permission <role-id> [flags]
+```
+
+### Examples
+
+```
+# Add a single permission
+qcloud iam role assign-permission 7b2ea926-724b-4de2-b73a-8675c42a6ebe --permission read:clusters
+
+# Add multiple permissions
+qcloud iam role assign-permission 7b2ea926-724b-4de2-b73a-8675c42a6ebe \
+  --permission read:clusters --permission read:backups
+```
+
+### Options
+
+```
+  -h, --help                 help for assign-permission
+      --permission strings   Permission to add (repeatable)
+```
+
+### Options inherited from parent commands
+
+```
+      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug               Enable debug logging to stderr
+      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                Output as JSON
+```
+
+### SEE ALSO
+
+* [qcloud iam role](qcloud_iam_role.md)	 - Manage roles in Qdrant Cloud
+

--- a/docs/reference/qcloud_iam_role_create.md
+++ b/docs/reference/qcloud_iam_role_create.md
@@ -1,0 +1,51 @@
+## qcloud iam role create
+
+Create a custom role
+
+### Synopsis
+
+Create a new custom role for the account.
+
+Custom roles allow fine-grained access control by combining specific permissions.
+Use "qcloud iam permission list" to see available permissions.
+
+```
+qcloud iam role create [flags]
+```
+
+### Examples
+
+```
+# Create a role with specific permissions
+qcloud iam role create --name "Cluster Viewer" --permission read:clusters --permission read:cluster-endpoints
+
+# Create a role with a description
+qcloud iam role create --name "Backup Manager" --description "Can manage backups" \
+  --permission read:clusters --permission read:backups --permission write:backups
+```
+
+### Options
+
+```
+      --description string   Description of the role
+  -h, --help                 help for create
+      --name string          Name of the role (4-64 characters)
+      --permission strings   Permission to assign (repeatable)
+```
+
+### Options inherited from parent commands
+
+```
+      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug               Enable debug logging to stderr
+      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                Output as JSON
+```
+
+### SEE ALSO
+
+* [qcloud iam role](qcloud_iam_role.md)	 - Manage roles in Qdrant Cloud
+

--- a/docs/reference/qcloud_iam_role_delete.md
+++ b/docs/reference/qcloud_iam_role_delete.md
@@ -1,0 +1,48 @@
+## qcloud iam role delete
+
+Delete a custom role
+
+### Synopsis
+
+Delete a custom role from the account.
+
+Only custom roles can be deleted. System roles are managed by Qdrant and cannot
+be removed.
+
+```
+qcloud iam role delete <role-id> [flags]
+```
+
+### Examples
+
+```
+# Delete a role (with confirmation prompt)
+qcloud iam role delete 7b2ea926-724b-4de2-b73a-8675c42a6ebe
+
+# Delete without confirmation
+qcloud iam role delete 7b2ea926-724b-4de2-b73a-8675c42a6ebe --force
+```
+
+### Options
+
+```
+  -f, --force   Skip confirmation prompt
+  -h, --help    help for delete
+```
+
+### Options inherited from parent commands
+
+```
+      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug               Enable debug logging to stderr
+      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                Output as JSON
+```
+
+### SEE ALSO
+
+* [qcloud iam role](qcloud_iam_role.md)	 - Manage roles in Qdrant Cloud
+

--- a/docs/reference/qcloud_iam_role_describe.md
+++ b/docs/reference/qcloud_iam_role_describe.md
@@ -1,0 +1,45 @@
+## qcloud iam role describe
+
+Describe a role
+
+### Synopsis
+
+Display detailed information about a role, including its name, type,
+description, and the full list of assigned permissions.
+
+```
+qcloud iam role describe <role-id> [flags]
+```
+
+### Examples
+
+```
+# Describe a role
+qcloud iam role describe 7b2ea926-724b-4de2-b73a-8675c42a6ebe
+
+# Output as JSON
+qcloud iam role describe 7b2ea926-724b-4de2-b73a-8675c42a6ebe --json
+```
+
+### Options
+
+```
+  -h, --help   help for describe
+```
+
+### Options inherited from parent commands
+
+```
+      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug               Enable debug logging to stderr
+      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                Output as JSON
+```
+
+### SEE ALSO
+
+* [qcloud iam role](qcloud_iam_role.md)	 - Manage roles in Qdrant Cloud
+

--- a/docs/reference/qcloud_iam_role_list.md
+++ b/docs/reference/qcloud_iam_role_list.md
@@ -1,0 +1,48 @@
+## qcloud iam role list
+
+List all roles
+
+### Synopsis
+
+List all roles for the account, including both system and custom roles.
+
+System roles are managed by Qdrant and cannot be modified. Custom roles are
+created and managed by the account administrator.
+
+```
+qcloud iam role list [flags]
+```
+
+### Examples
+
+```
+# List all roles
+qcloud iam role list
+
+# Output as JSON
+qcloud iam role list --json
+```
+
+### Options
+
+```
+  -h, --help         help for list
+      --no-headers   Do not print column headers
+```
+
+### Options inherited from parent commands
+
+```
+      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug               Enable debug logging to stderr
+      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                Output as JSON
+```
+
+### SEE ALSO
+
+* [qcloud iam role](qcloud_iam_role.md)	 - Manage roles in Qdrant Cloud
+

--- a/docs/reference/qcloud_iam_role_remove-permission.md
+++ b/docs/reference/qcloud_iam_role_remove-permission.md
@@ -1,0 +1,49 @@
+## qcloud iam role remove-permission
+
+Remove permissions from a role
+
+### Synopsis
+
+Remove permissions from a custom role.
+
+Fetches the role's current permissions, removes the specified ones, and updates
+the role. A role must retain at least one permission.
+
+```
+qcloud iam role remove-permission <role-id> [flags]
+```
+
+### Examples
+
+```
+# Remove a single permission
+qcloud iam role remove-permission 7b2ea926-724b-4de2-b73a-8675c42a6ebe --permission read:clusters
+
+# Remove multiple permissions
+qcloud iam role remove-permission 7b2ea926-724b-4de2-b73a-8675c42a6ebe \
+  --permission read:clusters --permission read:backups
+```
+
+### Options
+
+```
+  -h, --help                 help for remove-permission
+      --permission strings   Permission to remove (repeatable)
+```
+
+### Options inherited from parent commands
+
+```
+      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug               Enable debug logging to stderr
+      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                Output as JSON
+```
+
+### SEE ALSO
+
+* [qcloud iam role](qcloud_iam_role.md)	 - Manage roles in Qdrant Cloud
+

--- a/docs/reference/qcloud_iam_role_update.md
+++ b/docs/reference/qcloud_iam_role_update.md
@@ -1,0 +1,50 @@
+## qcloud iam role update
+
+Update a custom role
+
+### Synopsis
+
+Update the name or description of a custom role.
+
+Only custom roles can be updated. System roles are managed by Qdrant and cannot
+be modified. To change a role's permissions, use the assign-permission and
+remove-permission subcommands.
+
+```
+qcloud iam role update <role-id> [flags]
+```
+
+### Examples
+
+```
+# Rename a role
+qcloud iam role update 7b2ea926-724b-4de2-b73a-8675c42a6ebe --name "New Name"
+
+# Update the description
+qcloud iam role update 7b2ea926-724b-4de2-b73a-8675c42a6ebe --description "Updated description"
+```
+
+### Options
+
+```
+      --description string   New description for the role
+  -h, --help                 help for update
+      --name string          New name for the role
+```
+
+### Options inherited from parent commands
+
+```
+      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug               Enable debug logging to stderr
+      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                Output as JSON
+```
+
+### SEE ALSO
+
+* [qcloud iam role](qcloud_iam_role.md)	 - Manage roles in Qdrant Cloud
+

--- a/docs/reference/qcloud_iam_user.md
+++ b/docs/reference/qcloud_iam_user.md
@@ -1,0 +1,37 @@
+## qcloud iam user
+
+Manage users in Qdrant Cloud
+
+### Synopsis
+
+Manage users in the Qdrant Cloud account.
+
+Provides commands to list users, view user details and assigned roles, and
+manage role assignments.
+
+### Options
+
+```
+  -h, --help   help for user
+```
+
+### Options inherited from parent commands
+
+```
+      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug               Enable debug logging to stderr
+      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                Output as JSON
+```
+
+### SEE ALSO
+
+* [qcloud iam](qcloud_iam.md)	 - Manage IAM resources in Qdrant Cloud
+* [qcloud iam user assign-role](qcloud_iam_user_assign-role.md)	 - Assign one or more roles to a user
+* [qcloud iam user describe](qcloud_iam_user_describe.md)	 - Describe a user and their assigned roles
+* [qcloud iam user list](qcloud_iam_user_list.md)	 - List users in the account
+* [qcloud iam user remove-role](qcloud_iam_user_remove-role.md)	 - Remove one or more roles from a user
+

--- a/docs/reference/qcloud_iam_user_assign-role.md
+++ b/docs/reference/qcloud_iam_user_assign-role.md
@@ -1,0 +1,56 @@
+## qcloud iam user assign-role
+
+Assign one or more roles to a user
+
+### Synopsis
+
+Assign one or more roles to a user in the account.
+
+Accepts either a user ID (UUID) or an email address to identify the user.
+Each role accepts either a role UUID or a role name, which is
+resolved to an ID via the IAM service. Prints the user's resulting roles
+after the assignment.
+
+```
+qcloud iam user assign-role <user-id-or-email> [flags]
+```
+
+### Examples
+
+```
+# Assign a role by name
+qcloud iam user assign-role user@example.com --role admin
+
+# Assign a role by ID
+qcloud iam user assign-role user@example.com --role 7b2ea926-724b-4de2-b73a-8675c42a6ebe
+
+# Assign multiple roles at once
+qcloud iam user assign-role user@example.com --role admin --role viewer
+
+# Assign multiple roles at once using comma separated values
+qcloud iam user assign-role user@example.com --role admin,viewer
+```
+
+### Options
+
+```
+  -h, --help           help for assign-role
+  -r, --role strings   A role ID or name
+```
+
+### Options inherited from parent commands
+
+```
+      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug               Enable debug logging to stderr
+      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                Output as JSON
+```
+
+### SEE ALSO
+
+* [qcloud iam user](qcloud_iam_user.md)	 - Manage users in Qdrant Cloud
+

--- a/docs/reference/qcloud_iam_user_describe.md
+++ b/docs/reference/qcloud_iam_user_describe.md
@@ -1,0 +1,50 @@
+## qcloud iam user describe
+
+Describe a user and their assigned roles
+
+### Synopsis
+
+Describe a user and their assigned roles.
+
+Accepts either a user ID (UUID) or an email address. Displays the user's
+details and the roles currently assigned to them in the account.
+
+```
+qcloud iam user describe <user-id-or-email> [flags]
+```
+
+### Examples
+
+```
+# Describe a user by ID
+qcloud iam user describe 7b2ea926-724b-4de2-b73a-8675c42a6ebe
+
+# Describe a user by email
+qcloud iam user describe user@example.com
+
+# Output as JSON
+qcloud iam user describe user@example.com --json
+```
+
+### Options
+
+```
+  -h, --help   help for describe
+```
+
+### Options inherited from parent commands
+
+```
+      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug               Enable debug logging to stderr
+      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                Output as JSON
+```
+
+### SEE ALSO
+
+* [qcloud iam user](qcloud_iam_user.md)	 - Manage users in Qdrant Cloud
+

--- a/docs/reference/qcloud_iam_user_list.md
+++ b/docs/reference/qcloud_iam_user_list.md
@@ -1,0 +1,48 @@
+## qcloud iam user list
+
+List users in the account
+
+### Synopsis
+
+List users in the account.
+
+Lists all users who are members of the current account. Requires the read:users
+permission.
+
+```
+qcloud iam user list [flags]
+```
+
+### Examples
+
+```
+# List all users in the account
+qcloud iam user list
+
+# Output as JSON
+qcloud iam user list --json
+```
+
+### Options
+
+```
+  -h, --help         help for list
+      --no-headers   Do not print column headers
+```
+
+### Options inherited from parent commands
+
+```
+      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug               Enable debug logging to stderr
+      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                Output as JSON
+```
+
+### SEE ALSO
+
+* [qcloud iam user](qcloud_iam_user.md)	 - Manage users in Qdrant Cloud
+

--- a/docs/reference/qcloud_iam_user_remove-role.md
+++ b/docs/reference/qcloud_iam_user_remove-role.md
@@ -1,0 +1,53 @@
+## qcloud iam user remove-role
+
+Remove one or more roles from a user
+
+### Synopsis
+
+Remove one or more roles from a user in the account.
+
+Accepts either a user ID (UUID) or an email address to identify the user.
+Each role accepts either a role UUID or a role name, which is
+resolved to an ID via the IAM service. Prints the user's resulting roles
+after the removal.
+
+```
+qcloud iam user remove-role <user-id-or-email> [flags]
+```
+
+### Examples
+
+```
+# Remove a role by name
+qcloud iam user remove-role user@example.com --role admin
+
+# Remove a role by ID
+qcloud iam user remove-role user@example.com --role 7b2ea926-724b-4de2-b73a-8675c42a6ebe
+
+# Remove multiple roles at once
+qcloud iam user remove-role user@example.com --role admin --role viewer
+```
+
+### Options
+
+```
+  -h, --help           help for remove-role
+  -r, --role strings   A role ID or name
+```
+
+### Options inherited from parent commands
+
+```
+      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug               Enable debug logging to stderr
+      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                Output as JSON
+```
+
+### SEE ALSO
+
+* [qcloud iam user](qcloud_iam_user.md)	 - Manage users in Qdrant Cloud
+

--- a/docs/reference/qcloud_package.md
+++ b/docs/reference/qcloud_package.md
@@ -1,0 +1,27 @@
+## qcloud package
+
+Manage packages
+
+### Options
+
+```
+  -h, --help   help for package
+```
+
+### Options inherited from parent commands
+
+```
+      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug               Enable debug logging to stderr
+      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                Output as JSON
+```
+
+### SEE ALSO
+
+* [qcloud](qcloud.md)	 - Qdrant Cloud CLI
+* [qcloud package list](qcloud_package_list.md)	 - List available packages for cluster creation
+

--- a/docs/reference/qcloud_package_list.md
+++ b/docs/reference/qcloud_package_list.md
@@ -1,0 +1,43 @@
+## qcloud package list
+
+List available packages for cluster creation
+
+```
+qcloud package list [flags]
+```
+
+### Examples
+
+```
+# List packages for a cloud provider and region
+qcloud package list --cloud-provider aws --cloud-region eu-central-1
+
+# List packages for a hybrid cloud provider (no region required)
+qcloud package list --cloud-provider hybrid
+```
+
+### Options
+
+```
+      --cloud-provider string   Cloud provider ID (required)
+      --cloud-region string     Cloud provider region ID (required for non-hybrid providers)
+  -h, --help                    help for list
+      --no-headers              Do not print column headers
+```
+
+### Options inherited from parent commands
+
+```
+      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug               Enable debug logging to stderr
+      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                Output as JSON
+```
+
+### SEE ALSO
+
+* [qcloud package](qcloud_package.md)	 - Manage packages
+

--- a/docs/reference/qcloud_self-upgrade.md
+++ b/docs/reference/qcloud_self-upgrade.md
@@ -1,0 +1,32 @@
+## qcloud self-upgrade
+
+Upgrade qcloud to the latest version
+
+```
+qcloud self-upgrade [flags]
+```
+
+### Options
+
+```
+      --check   Only check for a new version without installing
+  -f, --force   Skip confirmation prompt
+  -h, --help    help for self-upgrade
+```
+
+### Options inherited from parent commands
+
+```
+      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug               Enable debug logging to stderr
+      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                Output as JSON
+```
+
+### SEE ALSO
+
+* [qcloud](qcloud.md)	 - Qdrant Cloud CLI
+

--- a/docs/reference/qcloud_version.md
+++ b/docs/reference/qcloud_version.md
@@ -1,0 +1,30 @@
+## qcloud version
+
+Print the qcloud CLI version
+
+```
+qcloud version [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for version
+```
+
+### Options inherited from parent commands
+
+```
+      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug               Enable debug logging to stderr
+      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                Output as JSON
+```
+
+### SEE ALSO
+
+* [qcloud](qcloud.md)	 - Qdrant Cloud CLI
+

--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	code.gitea.io/sdk/gitea v0.22.1 // indirect
 	github.com/42wim/httpsig v1.2.3 // indirect
 	github.com/Masterminds/semver/v3 v3.4.0 // indirect
+	github.com/cpuguy83/go-md2man/v2 v2.0.6 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/davidmz/go-pageant v1.0.2 // indirect
 	github.com/fsnotify/fsnotify v1.9.0 // indirect
@@ -38,6 +39,7 @@ require (
 	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
+	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/sagikazarmark/locafero v0.11.0 // indirect
 	github.com/sourcegraph/conc v0.3.1-0.20240121214520-5f936abd7ae8 // indirect
 	github.com/spf13/afero v1.15.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,7 @@ github.com/Masterminds/semver/v3 v3.4.0 h1:Zog+i5UMtVoCU8oKka5P7i9q9HgrJeGzI9SA1
 github.com/Masterminds/semver/v3 v3.4.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
+github.com/cpuguy83/go-md2man/v2 v2.0.6 h1:XJtiaUW6dEEqVuZiMTn1ldk455QWwEIsMIJlo5vtkx0=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/creativeprojects/go-selfupdate v1.5.2 h1:3KR3JLrq70oplb9yZzbmJ89qRP78D1AN/9u+l3k0LJ4=
 github.com/creativeprojects/go-selfupdate v1.5.2/go.mod h1:BCOuwIl1dRRCmPNRPH0amULeZqayhKyY2mH/h4va7Dk=
@@ -77,6 +78,7 @@ github.com/robfig/cron/v3 v3.0.1 h1:WdRxkvbJztn8LMz/QEvLN5sBU+xKpSqwwUO1Pjr4qDs=
 github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=
 github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZVejAe8=
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
+github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sagikazarmark/locafero v0.11.0 h1:1iurJgmM9G3PA/I+wWYIOw/5SyBtxapeHDcg+AAIFXc=
 github.com/sagikazarmark/locafero v0.11.0/go.mod h1:nVIGvgyzw595SUSUE6tvCp3YYTeHs15MvlmU87WwIik=


### PR DESCRIPTION
Added a subcommand to generate the docs reference using cobra/docs.

Added a CI check to avoid having stale documentation from CLI shape changes.

For reviewers, feel free to ignore the ./docs/reference files as they are auto generated. 