### PR TITLE
Add cluster dashboard command

### DIFF
--- a/docs/reference/qcloud.md
+++ b/docs/reference/qcloud.md
@@ -15,14 +15,15 @@ Documentation: https://github.com/qdrant/qcloud-cli
 ### Options
 
 ```
-      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
-      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
-  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
-      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
-      --debug               Enable debug logging to stderr
-      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
-  -h, --help                help for qcloud
-      --json                Output as JSON
+      --account-id string    Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string       Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string        Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --console-url string   Qdrant Cloud web console base URL (env: QDRANT_CLOUD_CONSOLE_URL, default https://cloud.qdrant.io)
+      --context string       Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug                Enable debug logging to stderr
+      --endpoint string      gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+  -h, --help                 help for qcloud
+      --json                 Output as JSON
 ```
 
 ### SEE ALSO

--- a/docs/reference/qcloud_account.md
+++ b/docs/reference/qcloud_account.md
@@ -19,13 +19,14 @@ current account and whether they are the owner.
 ### Options inherited from parent commands
 
 ```
-      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
-      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
-  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
-      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
-      --debug               Enable debug logging to stderr
-      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
-      --json                Output as JSON
+      --account-id string    Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string       Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string        Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --console-url string   Qdrant Cloud web console base URL (env: QDRANT_CLOUD_CONSOLE_URL, default https://cloud.qdrant.io)
+      --context string       Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug                Enable debug logging to stderr
+      --endpoint string      gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                 Output as JSON
 ```
 
 ### SEE ALSO

--- a/docs/reference/qcloud_account_describe.md
+++ b/docs/reference/qcloud_account_describe.md
@@ -35,13 +35,14 @@ qcloud account describe --json
 ### Options inherited from parent commands
 
 ```
-      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
-      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
-  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
-      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
-      --debug               Enable debug logging to stderr
-      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
-      --json                Output as JSON
+      --account-id string    Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string       Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string        Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --console-url string   Qdrant Cloud web console base URL (env: QDRANT_CLOUD_CONSOLE_URL, default https://cloud.qdrant.io)
+      --context string       Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug                Enable debug logging to stderr
+      --endpoint string      gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                 Output as JSON
 ```
 
 ### SEE ALSO

--- a/docs/reference/qcloud_account_list.md
+++ b/docs/reference/qcloud_account_list.md
@@ -33,13 +33,14 @@ qcloud account list --json
 ### Options inherited from parent commands
 
 ```
-      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
-      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
-  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
-      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
-      --debug               Enable debug logging to stderr
-      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
-      --json                Output as JSON
+      --account-id string    Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string       Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string        Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --console-url string   Qdrant Cloud web console base URL (env: QDRANT_CLOUD_CONSOLE_URL, default https://cloud.qdrant.io)
+      --context string       Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug                Enable debug logging to stderr
+      --endpoint string      gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                 Output as JSON
 ```
 
 ### SEE ALSO

--- a/docs/reference/qcloud_account_member.md
+++ b/docs/reference/qcloud_account_member.md
@@ -19,13 +19,14 @@ account owner.
 ### Options inherited from parent commands
 
 ```
-      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
-      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
-  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
-      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
-      --debug               Enable debug logging to stderr
-      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
-      --json                Output as JSON
+      --account-id string    Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string       Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string        Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --console-url string   Qdrant Cloud web console base URL (env: QDRANT_CLOUD_CONSOLE_URL, default https://cloud.qdrant.io)
+      --context string       Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug                Enable debug logging to stderr
+      --endpoint string      gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                 Output as JSON
 ```
 
 ### SEE ALSO

--- a/docs/reference/qcloud_account_member_describe.md
+++ b/docs/reference/qcloud_account_member_describe.md
@@ -31,13 +31,14 @@ qcloud account member describe a1b2c3d4-e5f6-7890-abcd-ef1234567890 --json
 ### Options inherited from parent commands
 
 ```
-      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
-      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
-  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
-      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
-      --debug               Enable debug logging to stderr
-      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
-      --json                Output as JSON
+      --account-id string    Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string       Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string        Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --console-url string   Qdrant Cloud web console base URL (env: QDRANT_CLOUD_CONSOLE_URL, default https://cloud.qdrant.io)
+      --context string       Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug                Enable debug logging to stderr
+      --endpoint string      gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                 Output as JSON
 ```
 
 ### SEE ALSO

--- a/docs/reference/qcloud_account_member_list.md
+++ b/docs/reference/qcloud_account_member_list.md
@@ -34,13 +34,14 @@ qcloud account member list --json
 ### Options inherited from parent commands
 
 ```
-      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
-      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
-  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
-      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
-      --debug               Enable debug logging to stderr
-      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
-      --json                Output as JSON
+      --account-id string    Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string       Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string        Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --console-url string   Qdrant Cloud web console base URL (env: QDRANT_CLOUD_CONSOLE_URL, default https://cloud.qdrant.io)
+      --context string       Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug                Enable debug logging to stderr
+      --endpoint string      gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                 Output as JSON
 ```
 
 ### SEE ALSO

--- a/docs/reference/qcloud_account_update.md
+++ b/docs/reference/qcloud_account_update.md
@@ -41,13 +41,14 @@ qcloud account update --name "New Name" --json
 ### Options inherited from parent commands
 
 ```
-      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
-      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
-  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
-      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
-      --debug               Enable debug logging to stderr
-      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
-      --json                Output as JSON
+      --account-id string    Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string       Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string        Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --console-url string   Qdrant Cloud web console base URL (env: QDRANT_CLOUD_CONSOLE_URL, default https://cloud.qdrant.io)
+      --context string       Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug                Enable debug logging to stderr
+      --endpoint string      gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                 Output as JSON
 ```
 
 ### SEE ALSO

--- a/docs/reference/qcloud_backup.md
+++ b/docs/reference/qcloud_backup.md
@@ -11,13 +11,14 @@ Manage Qdrant Cloud backups
 ### Options inherited from parent commands
 
 ```
-      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
-      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
-  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
-      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
-      --debug               Enable debug logging to stderr
-      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
-      --json                Output as JSON
+      --account-id string    Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string       Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string        Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --console-url string   Qdrant Cloud web console base URL (env: QDRANT_CLOUD_CONSOLE_URL, default https://cloud.qdrant.io)
+      --context string       Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug                Enable debug logging to stderr
+      --endpoint string      gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                 Output as JSON
 ```
 
 ### SEE ALSO

--- a/docs/reference/qcloud_backup_create.md
+++ b/docs/reference/qcloud_backup_create.md
@@ -17,13 +17,14 @@ qcloud backup create [flags]
 ### Options inherited from parent commands
 
 ```
-      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
-      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
-  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
-      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
-      --debug               Enable debug logging to stderr
-      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
-      --json                Output as JSON
+      --account-id string    Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string       Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string        Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --console-url string   Qdrant Cloud web console base URL (env: QDRANT_CLOUD_CONSOLE_URL, default https://cloud.qdrant.io)
+      --context string       Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug                Enable debug logging to stderr
+      --endpoint string      gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                 Output as JSON
 ```
 
 ### SEE ALSO

--- a/docs/reference/qcloud_backup_delete.md
+++ b/docs/reference/qcloud_backup_delete.md
@@ -16,13 +16,14 @@ qcloud backup delete <backup-id> [flags]
 ### Options inherited from parent commands
 
 ```
-      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
-      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
-  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
-      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
-      --debug               Enable debug logging to stderr
-      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
-      --json                Output as JSON
+      --account-id string    Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string       Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string        Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --console-url string   Qdrant Cloud web console base URL (env: QDRANT_CLOUD_CONSOLE_URL, default https://cloud.qdrant.io)
+      --context string       Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug                Enable debug logging to stderr
+      --endpoint string      gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                 Output as JSON
 ```
 
 ### SEE ALSO

--- a/docs/reference/qcloud_backup_describe.md
+++ b/docs/reference/qcloud_backup_describe.md
@@ -15,13 +15,14 @@ qcloud backup describe <backup-id> [flags]
 ### Options inherited from parent commands
 
 ```
-      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
-      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
-  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
-      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
-      --debug               Enable debug logging to stderr
-      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
-      --json                Output as JSON
+      --account-id string    Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string       Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string        Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --console-url string   Qdrant Cloud web console base URL (env: QDRANT_CLOUD_CONSOLE_URL, default https://cloud.qdrant.io)
+      --context string       Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug                Enable debug logging to stderr
+      --endpoint string      gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                 Output as JSON
 ```
 
 ### SEE ALSO

--- a/docs/reference/qcloud_backup_list.md
+++ b/docs/reference/qcloud_backup_list.md
@@ -17,13 +17,14 @@ qcloud backup list [flags]
 ### Options inherited from parent commands
 
 ```
-      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
-      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
-  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
-      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
-      --debug               Enable debug logging to stderr
-      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
-      --json                Output as JSON
+      --account-id string    Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string       Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string        Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --console-url string   Qdrant Cloud web console base URL (env: QDRANT_CLOUD_CONSOLE_URL, default https://cloud.qdrant.io)
+      --context string       Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug                Enable debug logging to stderr
+      --endpoint string      gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                 Output as JSON
 ```
 
 ### SEE ALSO

--- a/docs/reference/qcloud_backup_restore.md
+++ b/docs/reference/qcloud_backup_restore.md
@@ -11,13 +11,14 @@ Manage backup restores
 ### Options inherited from parent commands
 
 ```
-      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
-      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
-  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
-      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
-      --debug               Enable debug logging to stderr
-      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
-      --json                Output as JSON
+      --account-id string    Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string       Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string        Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --console-url string   Qdrant Cloud web console base URL (env: QDRANT_CLOUD_CONSOLE_URL, default https://cloud.qdrant.io)
+      --context string       Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug                Enable debug logging to stderr
+      --endpoint string      gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                 Output as JSON
 ```
 
 ### SEE ALSO

--- a/docs/reference/qcloud_backup_restore_list.md
+++ b/docs/reference/qcloud_backup_restore_list.md
@@ -17,13 +17,14 @@ qcloud backup restore list [flags]
 ### Options inherited from parent commands
 
 ```
-      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
-      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
-  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
-      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
-      --debug               Enable debug logging to stderr
-      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
-      --json                Output as JSON
+      --account-id string    Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string       Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string        Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --console-url string   Qdrant Cloud web console base URL (env: QDRANT_CLOUD_CONSOLE_URL, default https://cloud.qdrant.io)
+      --context string       Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug                Enable debug logging to stderr
+      --endpoint string      gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                 Output as JSON
 ```
 
 ### SEE ALSO

--- a/docs/reference/qcloud_backup_restore_trigger.md
+++ b/docs/reference/qcloud_backup_restore_trigger.md
@@ -16,13 +16,14 @@ qcloud backup restore trigger <backup-id> [flags]
 ### Options inherited from parent commands
 
 ```
-      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
-      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
-  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
-      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
-      --debug               Enable debug logging to stderr
-      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
-      --json                Output as JSON
+      --account-id string    Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string       Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string        Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --console-url string   Qdrant Cloud web console base URL (env: QDRANT_CLOUD_CONSOLE_URL, default https://cloud.qdrant.io)
+      --context string       Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug                Enable debug logging to stderr
+      --endpoint string      gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                 Output as JSON
 ```
 
 ### SEE ALSO

--- a/docs/reference/qcloud_backup_schedule.md
+++ b/docs/reference/qcloud_backup_schedule.md
@@ -11,13 +11,14 @@ Manage backup schedules
 ### Options inherited from parent commands
 
 ```
-      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
-      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
-  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
-      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
-      --debug               Enable debug logging to stderr
-      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
-      --json                Output as JSON
+      --account-id string    Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string       Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string        Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --console-url string   Qdrant Cloud web console base URL (env: QDRANT_CLOUD_CONSOLE_URL, default https://cloud.qdrant.io)
+      --context string       Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug                Enable debug logging to stderr
+      --endpoint string      gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                 Output as JSON
 ```
 
 ### SEE ALSO

--- a/docs/reference/qcloud_backup_schedule_create.md
+++ b/docs/reference/qcloud_backup_schedule_create.md
@@ -18,13 +18,14 @@ qcloud backup schedule create [flags]
 ### Options inherited from parent commands
 
 ```
-      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
-      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
-  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
-      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
-      --debug               Enable debug logging to stderr
-      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
-      --json                Output as JSON
+      --account-id string    Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string       Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string        Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --console-url string   Qdrant Cloud web console base URL (env: QDRANT_CLOUD_CONSOLE_URL, default https://cloud.qdrant.io)
+      --context string       Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug                Enable debug logging to stderr
+      --endpoint string      gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                 Output as JSON
 ```
 
 ### SEE ALSO

--- a/docs/reference/qcloud_backup_schedule_delete.md
+++ b/docs/reference/qcloud_backup_schedule_delete.md
@@ -17,13 +17,14 @@ qcloud backup schedule delete <schedule-id> [flags]
 ### Options inherited from parent commands
 
 ```
-      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
-      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
-  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
-      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
-      --debug               Enable debug logging to stderr
-      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
-      --json                Output as JSON
+      --account-id string    Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string       Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string        Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --console-url string   Qdrant Cloud web console base URL (env: QDRANT_CLOUD_CONSOLE_URL, default https://cloud.qdrant.io)
+      --context string       Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug                Enable debug logging to stderr
+      --endpoint string      gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                 Output as JSON
 ```
 
 ### SEE ALSO

--- a/docs/reference/qcloud_backup_schedule_describe.md
+++ b/docs/reference/qcloud_backup_schedule_describe.md
@@ -22,13 +22,14 @@ qcloud backup schedule describe <schedule-id> [flags]
 ### Options inherited from parent commands
 
 ```
-      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
-      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
-  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
-      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
-      --debug               Enable debug logging to stderr
-      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
-      --json                Output as JSON
+      --account-id string    Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string       Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string        Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --console-url string   Qdrant Cloud web console base URL (env: QDRANT_CLOUD_CONSOLE_URL, default https://cloud.qdrant.io)
+      --context string       Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug                Enable debug logging to stderr
+      --endpoint string      gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                 Output as JSON
 ```
 
 ### SEE ALSO

--- a/docs/reference/qcloud_backup_schedule_list.md
+++ b/docs/reference/qcloud_backup_schedule_list.md
@@ -17,13 +17,14 @@ qcloud backup schedule list [flags]
 ### Options inherited from parent commands
 
 ```
-      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
-      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
-  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
-      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
-      --debug               Enable debug logging to stderr
-      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
-      --json                Output as JSON
+      --account-id string    Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string       Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string        Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --console-url string   Qdrant Cloud web console base URL (env: QDRANT_CLOUD_CONSOLE_URL, default https://cloud.qdrant.io)
+      --context string       Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug                Enable debug logging to stderr
+      --endpoint string      gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                 Output as JSON
 ```
 
 ### SEE ALSO

--- a/docs/reference/qcloud_backup_schedule_update.md
+++ b/docs/reference/qcloud_backup_schedule_update.md
@@ -24,13 +24,14 @@ qcloud backup schedule update <schedule-id> [flags]
 ### Options inherited from parent commands
 
 ```
-      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
-      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
-  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
-      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
-      --debug               Enable debug logging to stderr
-      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
-      --json                Output as JSON
+      --account-id string    Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string       Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string        Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --console-url string   Qdrant Cloud web console base URL (env: QDRANT_CLOUD_CONSOLE_URL, default https://cloud.qdrant.io)
+      --context string       Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug                Enable debug logging to stderr
+      --endpoint string      gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                 Output as JSON
 ```
 
 ### SEE ALSO

--- a/docs/reference/qcloud_cloud-provider.md
+++ b/docs/reference/qcloud_cloud-provider.md
@@ -11,13 +11,14 @@ Manage cloud providers
 ### Options inherited from parent commands
 
 ```
-      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
-      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
-  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
-      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
-      --debug               Enable debug logging to stderr
-      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
-      --json                Output as JSON
+      --account-id string    Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string       Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string        Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --console-url string   Qdrant Cloud web console base URL (env: QDRANT_CLOUD_CONSOLE_URL, default https://cloud.qdrant.io)
+      --context string       Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug                Enable debug logging to stderr
+      --endpoint string      gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                 Output as JSON
 ```
 
 ### SEE ALSO

--- a/docs/reference/qcloud_cloud-provider_list.md
+++ b/docs/reference/qcloud_cloud-provider_list.md
@@ -16,13 +16,14 @@ qcloud cloud-provider list [flags]
 ### Options inherited from parent commands
 
 ```
-      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
-      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
-  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
-      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
-      --debug               Enable debug logging to stderr
-      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
-      --json                Output as JSON
+      --account-id string    Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string       Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string        Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --console-url string   Qdrant Cloud web console base URL (env: QDRANT_CLOUD_CONSOLE_URL, default https://cloud.qdrant.io)
+      --context string       Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug                Enable debug logging to stderr
+      --endpoint string      gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                 Output as JSON
 ```
 
 ### SEE ALSO

--- a/docs/reference/qcloud_cloud-region.md
+++ b/docs/reference/qcloud_cloud-region.md
@@ -11,13 +11,14 @@ Manage cloud regions
 ### Options inherited from parent commands
 
 ```
-      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
-      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
-  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
-      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
-      --debug               Enable debug logging to stderr
-      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
-      --json                Output as JSON
+      --account-id string    Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string       Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string        Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --console-url string   Qdrant Cloud web console base URL (env: QDRANT_CLOUD_CONSOLE_URL, default https://cloud.qdrant.io)
+      --context string       Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug                Enable debug logging to stderr
+      --endpoint string      gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                 Output as JSON
 ```
 
 ### SEE ALSO

--- a/docs/reference/qcloud_cloud-region_list.md
+++ b/docs/reference/qcloud_cloud-region_list.md
@@ -17,13 +17,14 @@ qcloud cloud-region list [flags]
 ### Options inherited from parent commands
 
 ```
-      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
-      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
-  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
-      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
-      --debug               Enable debug logging to stderr
-      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
-      --json                Output as JSON
+      --account-id string    Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string       Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string        Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --console-url string   Qdrant Cloud web console base URL (env: QDRANT_CLOUD_CONSOLE_URL, default https://cloud.qdrant.io)
+      --context string       Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug                Enable debug logging to stderr
+      --endpoint string      gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                 Output as JSON
 ```
 
 ### SEE ALSO

--- a/docs/reference/qcloud_cluster.md
+++ b/docs/reference/qcloud_cluster.md
@@ -11,13 +11,14 @@ Manage Qdrant Cloud clusters
 ### Options inherited from parent commands
 
 ```
-      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
-      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
-  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
-      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
-      --debug               Enable debug logging to stderr
-      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
-      --json                Output as JSON
+      --account-id string    Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string       Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string        Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --console-url string   Qdrant Cloud web console base URL (env: QDRANT_CLOUD_CONSOLE_URL, default https://cloud.qdrant.io)
+      --context string       Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug                Enable debug logging to stderr
+      --endpoint string      gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                 Output as JSON
 ```
 
 ### SEE ALSO
@@ -25,6 +26,7 @@ Manage Qdrant Cloud clusters
 * [qcloud](qcloud.md)	 - Qdrant Cloud CLI
 * [qcloud cluster create](qcloud_cluster_create.md)	 - Create a new cluster
 * [qcloud cluster create-from-backup](qcloud_cluster_create-from-backup.md)	 - Create a new cluster from a backup
+* [qcloud cluster dashboard](qcloud_cluster_dashboard.md)	 - Open a cluster's dashboard in your browser
 * [qcloud cluster delete](qcloud_cluster_delete.md)	 - Delete a cluster
 * [qcloud cluster describe](qcloud_cluster_describe.md)	 - Describe a cluster
 * [qcloud cluster key](qcloud_cluster_key.md)	 - Manage API keys for a cluster

--- a/docs/reference/qcloud_cluster_create-from-backup.md
+++ b/docs/reference/qcloud_cluster_create-from-backup.md
@@ -39,13 +39,14 @@ qcloud cluster create-from-backup --backup-id <backup-id> --name my-restored-clu
 ### Options inherited from parent commands
 
 ```
-      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
-      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
-  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
-      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
-      --debug               Enable debug logging to stderr
-      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
-      --json                Output as JSON
+      --account-id string    Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string       Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string        Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --console-url string   Qdrant Cloud web console base URL (env: QDRANT_CLOUD_CONSOLE_URL, default https://cloud.qdrant.io)
+      --context string       Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug                Enable debug logging to stderr
+      --endpoint string      gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                 Output as JSON
 ```
 
 ### SEE ALSO

--- a/docs/reference/qcloud_cluster_create.md
+++ b/docs/reference/qcloud_cluster_create.md
@@ -91,13 +91,14 @@ qcloud cluster create --cloud-provider hybrid --cloud-region my-env --cpu 4 --ra
 ### Options inherited from parent commands
 
 ```
-      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
-      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
-  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
-      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
-      --debug               Enable debug logging to stderr
-      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
-      --json                Output as JSON
+      --account-id string    Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string       Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string        Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --console-url string   Qdrant Cloud web console base URL (env: QDRANT_CLOUD_CONSOLE_URL, default https://cloud.qdrant.io)
+      --context string       Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug                Enable debug logging to stderr
+      --endpoint string      gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                 Output as JSON
 ```
 
 ### SEE ALSO

--- a/docs/reference/qcloud_cluster_dashboard.md
+++ b/docs/reference/qcloud_cluster_dashboard.md
@@ -1,26 +1,34 @@
-## qcloud context delete
+## qcloud cluster dashboard
 
-Delete a context
+Open a cluster's dashboard in your browser
+
+### Synopsis
+
+Open a cluster's dashboard in your default browser.
+
+The command builds the Cloud UI dashboard URL and opens it. The Cloud UI page
+handles authentication using your existing browser session and redirects to the
+cluster's dashboard.
 
 ```
-qcloud context delete <name> [flags]
+qcloud cluster dashboard <cluster-id> [flags]
 ```
 
 ### Examples
 
 ```
-# Delete a context
-qcloud context delete staging
+# Open a cluster's dashboard in your default browser
+qcloud cluster dashboard 7b2ea926-724b-4de2-b73a-8675c42a6ebe
 
-# Delete without confirmation
-qcloud context delete staging --force
+# Print the dashboard URL instead of opening a browser (headless/SSH)
+qcloud cluster dashboard 7b2ea926-724b-4de2-b73a-8675c42a6ebe --print-url
 ```
 
 ### Options
 
 ```
-  -f, --force   Skip confirmation prompt
-  -h, --help    help for delete
+  -h, --help        help for dashboard
+      --print-url   Print the dashboard URL instead of opening a browser
 ```
 
 ### Options inherited from parent commands
@@ -38,5 +46,5 @@ qcloud context delete staging --force
 
 ### SEE ALSO
 
-* [qcloud context](qcloud_context.md)	 - Manage named configuration contexts
+* [qcloud cluster](qcloud_cluster.md)	 - Manage Qdrant Cloud clusters
 

--- a/docs/reference/qcloud_cluster_delete.md
+++ b/docs/reference/qcloud_cluster_delete.md
@@ -26,13 +26,14 @@ qcloud cluster delete 7b2ea926-724b-4de2-b73a-8675c42a6ebe --force
 ### Options inherited from parent commands
 
 ```
-      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
-      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
-  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
-      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
-      --debug               Enable debug logging to stderr
-      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
-      --json                Output as JSON
+      --account-id string    Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string       Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string        Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --console-url string   Qdrant Cloud web console base URL (env: QDRANT_CLOUD_CONSOLE_URL, default https://cloud.qdrant.io)
+      --context string       Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug                Enable debug logging to stderr
+      --endpoint string      gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                 Output as JSON
 ```
 
 ### SEE ALSO

--- a/docs/reference/qcloud_cluster_describe.md
+++ b/docs/reference/qcloud_cluster_describe.md
@@ -25,13 +25,14 @@ qcloud cluster describe 7b2ea926-724b-4de2-b73a-8675c42a6ebe --json
 ### Options inherited from parent commands
 
 ```
-      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
-      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
-  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
-      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
-      --debug               Enable debug logging to stderr
-      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
-      --json                Output as JSON
+      --account-id string    Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string       Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string        Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --console-url string   Qdrant Cloud web console base URL (env: QDRANT_CLOUD_CONSOLE_URL, default https://cloud.qdrant.io)
+      --context string       Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug                Enable debug logging to stderr
+      --endpoint string      gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                 Output as JSON
 ```
 
 ### SEE ALSO

--- a/docs/reference/qcloud_cluster_key.md
+++ b/docs/reference/qcloud_cluster_key.md
@@ -11,13 +11,14 @@ Manage API keys for a cluster
 ### Options inherited from parent commands
 
 ```
-      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
-      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
-  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
-      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
-      --debug               Enable debug logging to stderr
-      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
-      --json                Output as JSON
+      --account-id string    Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string       Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string        Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --console-url string   Qdrant Cloud web console base URL (env: QDRANT_CLOUD_CONSOLE_URL, default https://cloud.qdrant.io)
+      --context string       Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug                Enable debug logging to stderr
+      --endpoint string      gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                 Output as JSON
 ```
 
 ### SEE ALSO

--- a/docs/reference/qcloud_cluster_key_create.md
+++ b/docs/reference/qcloud_cluster_key_create.md
@@ -35,13 +35,14 @@ qcloud cluster key create 7b2ea926-724b-4de2-b73a-8675c42a6ebe \
 ### Options inherited from parent commands
 
 ```
-      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
-      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
-  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
-      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
-      --debug               Enable debug logging to stderr
-      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
-      --json                Output as JSON
+      --account-id string    Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string       Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string        Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --console-url string   Qdrant Cloud web console base URL (env: QDRANT_CLOUD_CONSOLE_URL, default https://cloud.qdrant.io)
+      --context string       Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug                Enable debug logging to stderr
+      --endpoint string      gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                 Output as JSON
 ```
 
 ### SEE ALSO

--- a/docs/reference/qcloud_cluster_key_delete.md
+++ b/docs/reference/qcloud_cluster_key_delete.md
@@ -23,13 +23,14 @@ qcloud cluster key delete 7b2ea926-724b-4de2-b73a-8675c42a6ebe a1b2c3d4-e5f6-789
 ### Options inherited from parent commands
 
 ```
-      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
-      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
-  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
-      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
-      --debug               Enable debug logging to stderr
-      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
-      --json                Output as JSON
+      --account-id string    Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string       Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string        Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --console-url string   Qdrant Cloud web console base URL (env: QDRANT_CLOUD_CONSOLE_URL, default https://cloud.qdrant.io)
+      --context string       Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug                Enable debug logging to stderr
+      --endpoint string      gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                 Output as JSON
 ```
 
 ### SEE ALSO

--- a/docs/reference/qcloud_cluster_key_list.md
+++ b/docs/reference/qcloud_cluster_key_list.md
@@ -23,13 +23,14 @@ qcloud cluster key list 7b2ea926-724b-4de2-b73a-8675c42a6ebe
 ### Options inherited from parent commands
 
 ```
-      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
-      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
-  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
-      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
-      --debug               Enable debug logging to stderr
-      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
-      --json                Output as JSON
+      --account-id string    Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string       Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string        Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --console-url string   Qdrant Cloud web console base URL (env: QDRANT_CLOUD_CONSOLE_URL, default https://cloud.qdrant.io)
+      --context string       Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug                Enable debug logging to stderr
+      --endpoint string      gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                 Output as JSON
 ```
 
 ### SEE ALSO

--- a/docs/reference/qcloud_cluster_list.md
+++ b/docs/reference/qcloud_cluster_list.md
@@ -51,13 +51,14 @@ qcloud cluster list --page-size 10
 ### Options inherited from parent commands
 
 ```
-      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
-      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
-  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
-      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
-      --debug               Enable debug logging to stderr
-      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
-      --json                Output as JSON
+      --account-id string    Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string       Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string        Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --console-url string   Qdrant Cloud web console base URL (env: QDRANT_CLOUD_CONSOLE_URL, default https://cloud.qdrant.io)
+      --context string       Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug                Enable debug logging to stderr
+      --endpoint string      gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                 Output as JSON
 ```
 
 ### SEE ALSO

--- a/docs/reference/qcloud_cluster_logs.md
+++ b/docs/reference/qcloud_cluster_logs.md
@@ -34,13 +34,14 @@ qcloud cluster logs abc-123 --json
 ### Options inherited from parent commands
 
 ```
-      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
-      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
-  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
-      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
-      --debug               Enable debug logging to stderr
-      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
-      --json                Output as JSON
+      --account-id string    Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string       Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string        Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --console-url string   Qdrant Cloud web console base URL (env: QDRANT_CLOUD_CONSOLE_URL, default https://cloud.qdrant.io)
+      --context string       Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug                Enable debug logging to stderr
+      --endpoint string      gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                 Output as JSON
 ```
 
 ### SEE ALSO

--- a/docs/reference/qcloud_cluster_restart.md
+++ b/docs/reference/qcloud_cluster_restart.md
@@ -28,13 +28,14 @@ qcloud cluster restart 7b2ea926-724b-4de2-b73a-8675c42a6ebe --force --wait
 ### Options inherited from parent commands
 
 ```
-      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
-      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
-  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
-      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
-      --debug               Enable debug logging to stderr
-      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
-      --json                Output as JSON
+      --account-id string    Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string       Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string        Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --console-url string   Qdrant Cloud web console base URL (env: QDRANT_CLOUD_CONSOLE_URL, default https://cloud.qdrant.io)
+      --context string       Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug                Enable debug logging to stderr
+      --endpoint string      gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                 Output as JSON
 ```
 
 ### SEE ALSO

--- a/docs/reference/qcloud_cluster_scale.md
+++ b/docs/reference/qcloud_cluster_scale.md
@@ -56,13 +56,14 @@ qcloud cluster scale 7b2ea926-724b-4de2-b73a-8675c42a6ebe --disk 500Gi --wait
 ### Options inherited from parent commands
 
 ```
-      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
-      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
-  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
-      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
-      --debug               Enable debug logging to stderr
-      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
-      --json                Output as JSON
+      --account-id string    Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string       Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string        Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --console-url string   Qdrant Cloud web console base URL (env: QDRANT_CLOUD_CONSOLE_URL, default https://cloud.qdrant.io)
+      --context string       Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug                Enable debug logging to stderr
+      --endpoint string      gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                 Output as JSON
 ```
 
 ### SEE ALSO

--- a/docs/reference/qcloud_cluster_suspend.md
+++ b/docs/reference/qcloud_cluster_suspend.md
@@ -23,13 +23,14 @@ qcloud cluster suspend 7b2ea926-724b-4de2-b73a-8675c42a6ebe --force
 ### Options inherited from parent commands
 
 ```
-      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
-      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
-  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
-      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
-      --debug               Enable debug logging to stderr
-      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
-      --json                Output as JSON
+      --account-id string    Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string       Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string        Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --console-url string   Qdrant Cloud web console base URL (env: QDRANT_CLOUD_CONSOLE_URL, default https://cloud.qdrant.io)
+      --context string       Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug                Enable debug logging to stderr
+      --endpoint string      gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                 Output as JSON
 ```
 
 ### SEE ALSO

--- a/docs/reference/qcloud_cluster_unsuspend.md
+++ b/docs/reference/qcloud_cluster_unsuspend.md
@@ -22,13 +22,14 @@ qcloud cluster unsuspend 7b2ea926-724b-4de2-b73a-8675c42a6ebe
 ### Options inherited from parent commands
 
 ```
-      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
-      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
-  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
-      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
-      --debug               Enable debug logging to stderr
-      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
-      --json                Output as JSON
+      --account-id string    Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string       Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string        Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --console-url string   Qdrant Cloud web console base URL (env: QDRANT_CLOUD_CONSOLE_URL, default https://cloud.qdrant.io)
+      --context string       Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug                Enable debug logging to stderr
+      --endpoint string      gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                 Output as JSON
 ```
 
 ### SEE ALSO

--- a/docs/reference/qcloud_cluster_update.md
+++ b/docs/reference/qcloud_cluster_update.md
@@ -124,13 +124,14 @@ qcloud cluster update 7b2ea926-724b-4de2-b73a-8675c42a6ebe --database-storage-cl
 ### Options inherited from parent commands
 
 ```
-      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
-      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
-  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
-      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
-      --debug               Enable debug logging to stderr
-      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
-      --json                Output as JSON
+      --account-id string    Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string       Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string        Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --console-url string   Qdrant Cloud web console base URL (env: QDRANT_CLOUD_CONSOLE_URL, default https://cloud.qdrant.io)
+      --context string       Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug                Enable debug logging to stderr
+      --endpoint string      gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                 Output as JSON
 ```
 
 ### SEE ALSO

--- a/docs/reference/qcloud_cluster_version.md
+++ b/docs/reference/qcloud_cluster_version.md
@@ -11,13 +11,14 @@ Manage Qdrant versions
 ### Options inherited from parent commands
 
 ```
-      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
-      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
-  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
-      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
-      --debug               Enable debug logging to stderr
-      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
-      --json                Output as JSON
+      --account-id string    Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string       Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string        Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --console-url string   Qdrant Cloud web console base URL (env: QDRANT_CLOUD_CONSOLE_URL, default https://cloud.qdrant.io)
+      --context string       Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug                Enable debug logging to stderr
+      --endpoint string      gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                 Output as JSON
 ```
 
 ### SEE ALSO

--- a/docs/reference/qcloud_cluster_version_list.md
+++ b/docs/reference/qcloud_cluster_version_list.md
@@ -23,13 +23,14 @@ qcloud cluster version list
 ### Options inherited from parent commands
 
 ```
-      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
-      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
-  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
-      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
-      --debug               Enable debug logging to stderr
-      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
-      --json                Output as JSON
+      --account-id string    Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string       Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string        Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --console-url string   Qdrant Cloud web console base URL (env: QDRANT_CLOUD_CONSOLE_URL, default https://cloud.qdrant.io)
+      --context string       Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug                Enable debug logging to stderr
+      --endpoint string      gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                 Output as JSON
 ```
 
 ### SEE ALSO

--- a/docs/reference/qcloud_cluster_wait.md
+++ b/docs/reference/qcloud_cluster_wait.md
@@ -26,13 +26,14 @@ qcloud cluster wait 7b2ea926-724b-4de2-b73a-8675c42a6ebe --timeout 30m
 ### Options inherited from parent commands
 
 ```
-      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
-      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
-  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
-      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
-      --debug               Enable debug logging to stderr
-      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
-      --json                Output as JSON
+      --account-id string    Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string       Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string        Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --console-url string   Qdrant Cloud web console base URL (env: QDRANT_CLOUD_CONSOLE_URL, default https://cloud.qdrant.io)
+      --context string       Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug                Enable debug logging to stderr
+      --endpoint string      gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                 Output as JSON
 ```
 
 ### SEE ALSO

--- a/docs/reference/qcloud_context.md
+++ b/docs/reference/qcloud_context.md
@@ -11,13 +11,14 @@ Manage named configuration contexts
 ### Options inherited from parent commands
 
 ```
-      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
-      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
-  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
-      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
-      --debug               Enable debug logging to stderr
-      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
-      --json                Output as JSON
+      --account-id string    Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string       Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string        Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --console-url string   Qdrant Cloud web console base URL (env: QDRANT_CLOUD_CONSOLE_URL, default https://cloud.qdrant.io)
+      --context string       Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug                Enable debug logging to stderr
+      --endpoint string      gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                 Output as JSON
 ```
 
 ### SEE ALSO

--- a/docs/reference/qcloud_context_list.md
+++ b/docs/reference/qcloud_context_list.md
@@ -22,13 +22,14 @@ qcloud context list
 ### Options inherited from parent commands
 
 ```
-      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
-      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
-  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
-      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
-      --debug               Enable debug logging to stderr
-      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
-      --json                Output as JSON
+      --account-id string    Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string       Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string        Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --console-url string   Qdrant Cloud web console base URL (env: QDRANT_CLOUD_CONSOLE_URL, default https://cloud.qdrant.io)
+      --context string       Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug                Enable debug logging to stderr
+      --endpoint string      gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                 Output as JSON
 ```
 
 ### SEE ALSO

--- a/docs/reference/qcloud_context_set.md
+++ b/docs/reference/qcloud_context_set.md
@@ -66,10 +66,11 @@ qcloud context set staging --api-key-helper 1password --api-key-ref op://vault/q
 ### Options inherited from parent commands
 
 ```
-  -c, --config string    Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
-      --context string   Override the active context (env: QDRANT_CLOUD_CONTEXT)
-      --debug            Enable debug logging to stderr
-      --json             Output as JSON
+  -c, --config string        Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --console-url string   Qdrant Cloud web console base URL (env: QDRANT_CLOUD_CONSOLE_URL, default https://cloud.qdrant.io)
+      --context string       Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug                Enable debug logging to stderr
+      --json                 Output as JSON
 ```
 
 ### SEE ALSO

--- a/docs/reference/qcloud_context_show.md
+++ b/docs/reference/qcloud_context_show.md
@@ -22,13 +22,14 @@ qcloud context show
 ### Options inherited from parent commands
 
 ```
-      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
-      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
-  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
-      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
-      --debug               Enable debug logging to stderr
-      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
-      --json                Output as JSON
+      --account-id string    Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string       Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string        Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --console-url string   Qdrant Cloud web console base URL (env: QDRANT_CLOUD_CONSOLE_URL, default https://cloud.qdrant.io)
+      --context string       Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug                Enable debug logging to stderr
+      --endpoint string      gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                 Output as JSON
 ```
 
 ### SEE ALSO

--- a/docs/reference/qcloud_context_use.md
+++ b/docs/reference/qcloud_context_use.md
@@ -22,13 +22,14 @@ qcloud context use production
 ### Options inherited from parent commands
 
 ```
-      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
-      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
-  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
-      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
-      --debug               Enable debug logging to stderr
-      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
-      --json                Output as JSON
+      --account-id string    Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string       Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string        Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --console-url string   Qdrant Cloud web console base URL (env: QDRANT_CLOUD_CONSOLE_URL, default https://cloud.qdrant.io)
+      --context string       Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug                Enable debug logging to stderr
+      --endpoint string      gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                 Output as JSON
 ```
 
 ### SEE ALSO

--- a/docs/reference/qcloud_hybrid.md
+++ b/docs/reference/qcloud_hybrid.md
@@ -11,13 +11,14 @@ Manage hybrid cloud environments
 ### Options inherited from parent commands
 
 ```
-      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
-      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
-  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
-      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
-      --debug               Enable debug logging to stderr
-      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
-      --json                Output as JSON
+      --account-id string    Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string       Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string        Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --console-url string   Qdrant Cloud web console base URL (env: QDRANT_CLOUD_CONSOLE_URL, default https://cloud.qdrant.io)
+      --context string       Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug                Enable debug logging to stderr
+      --endpoint string      gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                 Output as JSON
 ```
 
 ### SEE ALSO

--- a/docs/reference/qcloud_hybrid_bootstrap.md
+++ b/docs/reference/qcloud_hybrid_bootstrap.md
@@ -35,13 +35,14 @@ qcloud hybrid bootstrap 7b2ea926-724b-4de2-b73a-8675c42a6ebe | bash
 ### Options inherited from parent commands
 
 ```
-      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
-      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
-  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
-      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
-      --debug               Enable debug logging to stderr
-      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
-      --json                Output as JSON
+      --account-id string    Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string       Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string        Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --console-url string   Qdrant Cloud web console base URL (env: QDRANT_CLOUD_CONSOLE_URL, default https://cloud.qdrant.io)
+      --context string       Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug                Enable debug logging to stderr
+      --endpoint string      gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                 Output as JSON
 ```
 
 ### SEE ALSO

--- a/docs/reference/qcloud_hybrid_create.md
+++ b/docs/reference/qcloud_hybrid_create.md
@@ -43,13 +43,14 @@ qcloud hybrid create --name my-hybrid-env \
 ### Options inherited from parent commands
 
 ```
-      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
-      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
-  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
-      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
-      --debug               Enable debug logging to stderr
-      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
-      --json                Output as JSON
+      --account-id string    Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string       Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string        Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --console-url string   Qdrant Cloud web console base URL (env: QDRANT_CLOUD_CONSOLE_URL, default https://cloud.qdrant.io)
+      --context string       Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug                Enable debug logging to stderr
+      --endpoint string      gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                 Output as JSON
 ```
 
 ### SEE ALSO

--- a/docs/reference/qcloud_hybrid_delete.md
+++ b/docs/reference/qcloud_hybrid_delete.md
@@ -26,13 +26,14 @@ qcloud hybrid delete 7b2ea926-724b-4de2-b73a-8675c42a6ebe --force
 ### Options inherited from parent commands
 
 ```
-      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
-      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
-  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
-      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
-      --debug               Enable debug logging to stderr
-      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
-      --json                Output as JSON
+      --account-id string    Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string       Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string        Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --console-url string   Qdrant Cloud web console base URL (env: QDRANT_CLOUD_CONSOLE_URL, default https://cloud.qdrant.io)
+      --context string       Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug                Enable debug logging to stderr
+      --endpoint string      gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                 Output as JSON
 ```
 
 ### SEE ALSO

--- a/docs/reference/qcloud_hybrid_describe.md
+++ b/docs/reference/qcloud_hybrid_describe.md
@@ -15,13 +15,14 @@ qcloud hybrid describe <env-id> [flags]
 ### Options inherited from parent commands
 
 ```
-      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
-      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
-  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
-      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
-      --debug               Enable debug logging to stderr
-      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
-      --json                Output as JSON
+      --account-id string    Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string       Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string        Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --console-url string   Qdrant Cloud web console base URL (env: QDRANT_CLOUD_CONSOLE_URL, default https://cloud.qdrant.io)
+      --context string       Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug                Enable debug logging to stderr
+      --endpoint string      gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                 Output as JSON
 ```
 
 ### SEE ALSO

--- a/docs/reference/qcloud_hybrid_list.md
+++ b/docs/reference/qcloud_hybrid_list.md
@@ -16,13 +16,14 @@ qcloud hybrid list [flags]
 ### Options inherited from parent commands
 
 ```
-      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
-      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
-  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
-      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
-      --debug               Enable debug logging to stderr
-      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
-      --json                Output as JSON
+      --account-id string    Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string       Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string        Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --console-url string   Qdrant Cloud web console base URL (env: QDRANT_CLOUD_CONSOLE_URL, default https://cloud.qdrant.io)
+      --context string       Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug                Enable debug logging to stderr
+      --endpoint string      gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                 Output as JSON
 ```
 
 ### SEE ALSO

--- a/docs/reference/qcloud_hybrid_update.md
+++ b/docs/reference/qcloud_hybrid_update.md
@@ -34,13 +34,14 @@ qcloud hybrid update 7b2ea926-724b-4de2-b73a-8675c42a6ebe --log-level debug
 ### Options inherited from parent commands
 
 ```
-      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
-      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
-  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
-      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
-      --debug               Enable debug logging to stderr
-      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
-      --json                Output as JSON
+      --account-id string    Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string       Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string        Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --console-url string   Qdrant Cloud web console base URL (env: QDRANT_CLOUD_CONSOLE_URL, default https://cloud.qdrant.io)
+      --context string       Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug                Enable debug logging to stderr
+      --endpoint string      gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                 Output as JSON
 ```
 
 ### SEE ALSO

--- a/docs/reference/qcloud_iam.md
+++ b/docs/reference/qcloud_iam.md
@@ -15,13 +15,14 @@ Manage IAM resources for the Qdrant Cloud account.
 ### Options inherited from parent commands
 
 ```
-      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
-      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
-  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
-      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
-      --debug               Enable debug logging to stderr
-      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
-      --json                Output as JSON
+      --account-id string    Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string       Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string        Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --console-url string   Qdrant Cloud web console base URL (env: QDRANT_CLOUD_CONSOLE_URL, default https://cloud.qdrant.io)
+      --context string       Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug                Enable debug logging to stderr
+      --endpoint string      gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                 Output as JSON
 ```
 
 ### SEE ALSO

--- a/docs/reference/qcloud_iam_key.md
+++ b/docs/reference/qcloud_iam_key.md
@@ -18,13 +18,14 @@ the CLI, automation scripts, or any other tooling that calls the Qdrant Cloud AP
 ### Options inherited from parent commands
 
 ```
-      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
-      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
-  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
-      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
-      --debug               Enable debug logging to stderr
-      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
-      --json                Output as JSON
+      --account-id string    Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string       Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string        Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --console-url string   Qdrant Cloud web console base URL (env: QDRANT_CLOUD_CONSOLE_URL, default https://cloud.qdrant.io)
+      --context string       Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug                Enable debug logging to stderr
+      --endpoint string      gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                 Output as JSON
 ```
 
 ### SEE ALSO

--- a/docs/reference/qcloud_iam_key_create.md
+++ b/docs/reference/qcloud_iam_key_create.md
@@ -33,13 +33,14 @@ qcloud iam key create --json | jq -r '.key'
 ### Options inherited from parent commands
 
 ```
-      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
-      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
-  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
-      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
-      --debug               Enable debug logging to stderr
-      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
-      --json                Output as JSON
+      --account-id string    Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string       Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string        Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --console-url string   Qdrant Cloud web console base URL (env: QDRANT_CLOUD_CONSOLE_URL, default https://cloud.qdrant.io)
+      --context string       Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug                Enable debug logging to stderr
+      --endpoint string      gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                 Output as JSON
 ```
 
 ### SEE ALSO

--- a/docs/reference/qcloud_iam_key_delete.md
+++ b/docs/reference/qcloud_iam_key_delete.md
@@ -35,13 +35,14 @@ qcloud iam key delete a1b2c3d4-e5f6-7890-abcd-ef1234567890 --force
 ### Options inherited from parent commands
 
 ```
-      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
-      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
-  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
-      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
-      --debug               Enable debug logging to stderr
-      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
-      --json                Output as JSON
+      --account-id string    Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string       Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string        Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --console-url string   Qdrant Cloud web console base URL (env: QDRANT_CLOUD_CONSOLE_URL, default https://cloud.qdrant.io)
+      --context string       Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug                Enable debug logging to stderr
+      --endpoint string      gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                 Output as JSON
 ```
 
 ### SEE ALSO

--- a/docs/reference/qcloud_iam_key_list.md
+++ b/docs/reference/qcloud_iam_key_list.md
@@ -34,13 +34,14 @@ qcloud iam key list --json
 ### Options inherited from parent commands
 
 ```
-      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
-      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
-  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
-      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
-      --debug               Enable debug logging to stderr
-      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
-      --json                Output as JSON
+      --account-id string    Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string       Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string        Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --console-url string   Qdrant Cloud web console base URL (env: QDRANT_CLOUD_CONSOLE_URL, default https://cloud.qdrant.io)
+      --context string       Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug                Enable debug logging to stderr
+      --endpoint string      gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                 Output as JSON
 ```
 
 ### SEE ALSO

--- a/docs/reference/qcloud_iam_permission.md
+++ b/docs/reference/qcloud_iam_permission.md
@@ -18,13 +18,14 @@ Use these commands to discover which permissions are available in the system.
 ### Options inherited from parent commands
 
 ```
-      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
-      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
-  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
-      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
-      --debug               Enable debug logging to stderr
-      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
-      --json                Output as JSON
+      --account-id string    Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string       Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string        Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --console-url string   Qdrant Cloud web console base URL (env: QDRANT_CLOUD_CONSOLE_URL, default https://cloud.qdrant.io)
+      --context string       Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug                Enable debug logging to stderr
+      --endpoint string      gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                 Output as JSON
 ```
 
 ### SEE ALSO

--- a/docs/reference/qcloud_iam_permission_list.md
+++ b/docs/reference/qcloud_iam_permission_list.md
@@ -34,13 +34,14 @@ qcloud iam permission list --json
 ### Options inherited from parent commands
 
 ```
-      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
-      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
-  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
-      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
-      --debug               Enable debug logging to stderr
-      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
-      --json                Output as JSON
+      --account-id string    Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string       Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string        Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --console-url string   Qdrant Cloud web console base URL (env: QDRANT_CLOUD_CONSOLE_URL, default https://cloud.qdrant.io)
+      --context string       Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug                Enable debug logging to stderr
+      --endpoint string      gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                 Output as JSON
 ```
 
 ### SEE ALSO

--- a/docs/reference/qcloud_iam_role.md
+++ b/docs/reference/qcloud_iam_role.md
@@ -20,13 +20,14 @@ update, and delete custom roles, as well as manage their permissions.
 ### Options inherited from parent commands
 
 ```
-      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
-      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
-  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
-      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
-      --debug               Enable debug logging to stderr
-      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
-      --json                Output as JSON
+      --account-id string    Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string       Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string        Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --console-url string   Qdrant Cloud web console base URL (env: QDRANT_CLOUD_CONSOLE_URL, default https://cloud.qdrant.io)
+      --context string       Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug                Enable debug logging to stderr
+      --endpoint string      gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                 Output as JSON
 ```
 
 ### SEE ALSO

--- a/docs/reference/qcloud_iam_role_assign-permission.md
+++ b/docs/reference/qcloud_iam_role_assign-permission.md
@@ -35,13 +35,14 @@ qcloud iam role assign-permission 7b2ea926-724b-4de2-b73a-8675c42a6ebe \
 ### Options inherited from parent commands
 
 ```
-      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
-      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
-  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
-      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
-      --debug               Enable debug logging to stderr
-      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
-      --json                Output as JSON
+      --account-id string    Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string       Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string        Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --console-url string   Qdrant Cloud web console base URL (env: QDRANT_CLOUD_CONSOLE_URL, default https://cloud.qdrant.io)
+      --context string       Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug                Enable debug logging to stderr
+      --endpoint string      gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                 Output as JSON
 ```
 
 ### SEE ALSO

--- a/docs/reference/qcloud_iam_role_create.md
+++ b/docs/reference/qcloud_iam_role_create.md
@@ -36,13 +36,14 @@ qcloud iam role create --name "Backup Manager" --description "Can manage backups
 ### Options inherited from parent commands
 
 ```
-      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
-      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
-  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
-      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
-      --debug               Enable debug logging to stderr
-      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
-      --json                Output as JSON
+      --account-id string    Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string       Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string        Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --console-url string   Qdrant Cloud web console base URL (env: QDRANT_CLOUD_CONSOLE_URL, default https://cloud.qdrant.io)
+      --context string       Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug                Enable debug logging to stderr
+      --endpoint string      gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                 Output as JSON
 ```
 
 ### SEE ALSO

--- a/docs/reference/qcloud_iam_role_delete.md
+++ b/docs/reference/qcloud_iam_role_delete.md
@@ -33,13 +33,14 @@ qcloud iam role delete 7b2ea926-724b-4de2-b73a-8675c42a6ebe --force
 ### Options inherited from parent commands
 
 ```
-      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
-      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
-  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
-      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
-      --debug               Enable debug logging to stderr
-      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
-      --json                Output as JSON
+      --account-id string    Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string       Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string        Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --console-url string   Qdrant Cloud web console base URL (env: QDRANT_CLOUD_CONSOLE_URL, default https://cloud.qdrant.io)
+      --context string       Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug                Enable debug logging to stderr
+      --endpoint string      gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                 Output as JSON
 ```
 
 ### SEE ALSO

--- a/docs/reference/qcloud_iam_role_describe.md
+++ b/docs/reference/qcloud_iam_role_describe.md
@@ -30,13 +30,14 @@ qcloud iam role describe 7b2ea926-724b-4de2-b73a-8675c42a6ebe --json
 ### Options inherited from parent commands
 
 ```
-      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
-      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
-  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
-      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
-      --debug               Enable debug logging to stderr
-      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
-      --json                Output as JSON
+      --account-id string    Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string       Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string        Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --console-url string   Qdrant Cloud web console base URL (env: QDRANT_CLOUD_CONSOLE_URL, default https://cloud.qdrant.io)
+      --context string       Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug                Enable debug logging to stderr
+      --endpoint string      gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                 Output as JSON
 ```
 
 ### SEE ALSO

--- a/docs/reference/qcloud_iam_role_list.md
+++ b/docs/reference/qcloud_iam_role_list.md
@@ -33,13 +33,14 @@ qcloud iam role list --json
 ### Options inherited from parent commands
 
 ```
-      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
-      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
-  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
-      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
-      --debug               Enable debug logging to stderr
-      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
-      --json                Output as JSON
+      --account-id string    Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string       Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string        Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --console-url string   Qdrant Cloud web console base URL (env: QDRANT_CLOUD_CONSOLE_URL, default https://cloud.qdrant.io)
+      --context string       Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug                Enable debug logging to stderr
+      --endpoint string      gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                 Output as JSON
 ```
 
 ### SEE ALSO

--- a/docs/reference/qcloud_iam_role_remove-permission.md
+++ b/docs/reference/qcloud_iam_role_remove-permission.md
@@ -34,13 +34,14 @@ qcloud iam role remove-permission 7b2ea926-724b-4de2-b73a-8675c42a6ebe \
 ### Options inherited from parent commands
 
 ```
-      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
-      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
-  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
-      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
-      --debug               Enable debug logging to stderr
-      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
-      --json                Output as JSON
+      --account-id string    Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string       Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string        Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --console-url string   Qdrant Cloud web console base URL (env: QDRANT_CLOUD_CONSOLE_URL, default https://cloud.qdrant.io)
+      --context string       Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug                Enable debug logging to stderr
+      --endpoint string      gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                 Output as JSON
 ```
 
 ### SEE ALSO

--- a/docs/reference/qcloud_iam_role_update.md
+++ b/docs/reference/qcloud_iam_role_update.md
@@ -35,13 +35,14 @@ qcloud iam role update 7b2ea926-724b-4de2-b73a-8675c42a6ebe --description "Updat
 ### Options inherited from parent commands
 
 ```
-      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
-      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
-  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
-      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
-      --debug               Enable debug logging to stderr
-      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
-      --json                Output as JSON
+      --account-id string    Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string       Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string        Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --console-url string   Qdrant Cloud web console base URL (env: QDRANT_CLOUD_CONSOLE_URL, default https://cloud.qdrant.io)
+      --context string       Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug                Enable debug logging to stderr
+      --endpoint string      gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                 Output as JSON
 ```
 
 ### SEE ALSO

--- a/docs/reference/qcloud_iam_user.md
+++ b/docs/reference/qcloud_iam_user.md
@@ -18,13 +18,14 @@ manage role assignments.
 ### Options inherited from parent commands
 
 ```
-      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
-      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
-  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
-      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
-      --debug               Enable debug logging to stderr
-      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
-      --json                Output as JSON
+      --account-id string    Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string       Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string        Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --console-url string   Qdrant Cloud web console base URL (env: QDRANT_CLOUD_CONSOLE_URL, default https://cloud.qdrant.io)
+      --context string       Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug                Enable debug logging to stderr
+      --endpoint string      gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                 Output as JSON
 ```
 
 ### SEE ALSO

--- a/docs/reference/qcloud_iam_user_assign-role.md
+++ b/docs/reference/qcloud_iam_user_assign-role.md
@@ -41,13 +41,14 @@ qcloud iam user assign-role user@example.com --role admin,viewer
 ### Options inherited from parent commands
 
 ```
-      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
-      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
-  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
-      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
-      --debug               Enable debug logging to stderr
-      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
-      --json                Output as JSON
+      --account-id string    Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string       Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string        Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --console-url string   Qdrant Cloud web console base URL (env: QDRANT_CLOUD_CONSOLE_URL, default https://cloud.qdrant.io)
+      --context string       Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug                Enable debug logging to stderr
+      --endpoint string      gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                 Output as JSON
 ```
 
 ### SEE ALSO

--- a/docs/reference/qcloud_iam_user_delete.md
+++ b/docs/reference/qcloud_iam_user_delete.md
@@ -39,13 +39,14 @@ qcloud iam user delete user@example.com --force
 ### Options inherited from parent commands
 
 ```
-      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
-      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
-  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
-      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
-      --debug               Enable debug logging to stderr
-      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
-      --json                Output as JSON
+      --account-id string    Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string       Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string        Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --console-url string   Qdrant Cloud web console base URL (env: QDRANT_CLOUD_CONSOLE_URL, default https://cloud.qdrant.io)
+      --context string       Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug                Enable debug logging to stderr
+      --endpoint string      gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                 Output as JSON
 ```
 
 ### SEE ALSO

--- a/docs/reference/qcloud_iam_user_describe.md
+++ b/docs/reference/qcloud_iam_user_describe.md
@@ -35,13 +35,14 @@ qcloud iam user describe user@example.com --json
 ### Options inherited from parent commands
 
 ```
-      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
-      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
-  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
-      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
-      --debug               Enable debug logging to stderr
-      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
-      --json                Output as JSON
+      --account-id string    Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string       Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string        Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --console-url string   Qdrant Cloud web console base URL (env: QDRANT_CLOUD_CONSOLE_URL, default https://cloud.qdrant.io)
+      --context string       Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug                Enable debug logging to stderr
+      --endpoint string      gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                 Output as JSON
 ```
 
 ### SEE ALSO

--- a/docs/reference/qcloud_iam_user_list.md
+++ b/docs/reference/qcloud_iam_user_list.md
@@ -33,13 +33,14 @@ qcloud iam user list --json
 ### Options inherited from parent commands
 
 ```
-      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
-      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
-  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
-      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
-      --debug               Enable debug logging to stderr
-      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
-      --json                Output as JSON
+      --account-id string    Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string       Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string        Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --console-url string   Qdrant Cloud web console base URL (env: QDRANT_CLOUD_CONSOLE_URL, default https://cloud.qdrant.io)
+      --context string       Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug                Enable debug logging to stderr
+      --endpoint string      gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                 Output as JSON
 ```
 
 ### SEE ALSO

--- a/docs/reference/qcloud_iam_user_remove-role.md
+++ b/docs/reference/qcloud_iam_user_remove-role.md
@@ -38,13 +38,14 @@ qcloud iam user remove-role user@example.com --role admin --role viewer
 ### Options inherited from parent commands
 
 ```
-      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
-      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
-  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
-      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
-      --debug               Enable debug logging to stderr
-      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
-      --json                Output as JSON
+      --account-id string    Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string       Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string        Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --console-url string   Qdrant Cloud web console base URL (env: QDRANT_CLOUD_CONSOLE_URL, default https://cloud.qdrant.io)
+      --context string       Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug                Enable debug logging to stderr
+      --endpoint string      gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                 Output as JSON
 ```
 
 ### SEE ALSO

--- a/docs/reference/qcloud_package.md
+++ b/docs/reference/qcloud_package.md
@@ -11,13 +11,14 @@ Manage packages
 ### Options inherited from parent commands
 
 ```
-      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
-      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
-  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
-      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
-      --debug               Enable debug logging to stderr
-      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
-      --json                Output as JSON
+      --account-id string    Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string       Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string        Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --console-url string   Qdrant Cloud web console base URL (env: QDRANT_CLOUD_CONSOLE_URL, default https://cloud.qdrant.io)
+      --context string       Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug                Enable debug logging to stderr
+      --endpoint string      gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                 Output as JSON
 ```
 
 ### SEE ALSO

--- a/docs/reference/qcloud_package_list.md
+++ b/docs/reference/qcloud_package_list.md
@@ -28,13 +28,14 @@ qcloud package list --cloud-provider hybrid
 ### Options inherited from parent commands
 
 ```
-      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
-      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
-  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
-      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
-      --debug               Enable debug logging to stderr
-      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
-      --json                Output as JSON
+      --account-id string    Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string       Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string        Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --console-url string   Qdrant Cloud web console base URL (env: QDRANT_CLOUD_CONSOLE_URL, default https://cloud.qdrant.io)
+      --context string       Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug                Enable debug logging to stderr
+      --endpoint string      gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                 Output as JSON
 ```
 
 ### SEE ALSO

--- a/docs/reference/qcloud_self-upgrade.md
+++ b/docs/reference/qcloud_self-upgrade.md
@@ -17,13 +17,14 @@ qcloud self-upgrade [flags]
 ### Options inherited from parent commands
 
 ```
-      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
-      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
-  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
-      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
-      --debug               Enable debug logging to stderr
-      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
-      --json                Output as JSON
+      --account-id string    Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string       Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string        Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --console-url string   Qdrant Cloud web console base URL (env: QDRANT_CLOUD_CONSOLE_URL, default https://cloud.qdrant.io)
+      --context string       Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug                Enable debug logging to stderr
+      --endpoint string      gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                 Output as JSON
 ```
 
 ### SEE ALSO

--- a/docs/reference/qcloud_version.md
+++ b/docs/reference/qcloud_version.md
@@ -15,13 +15,14 @@ qcloud version [flags]
 ### Options inherited from parent commands
 
 ```
-      --account-id string   Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
-      --api-key string      Management API Key (env: QDRANT_CLOUD_API_KEY)
-  -c, --config string       Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
-      --context string      Override the active context (env: QDRANT_CLOUD_CONTEXT)
-      --debug               Enable debug logging to stderr
-      --endpoint string     gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
-      --json                Output as JSON
+      --account-id string    Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)
+      --api-key string       Management API Key (env: QDRANT_CLOUD_API_KEY)
+  -c, --config string        Config file path (env: QDRANT_CLOUD_CONFIG, default ~/.config/qcloud/config.yaml)
+      --console-url string   Qdrant Cloud web console base URL (env: QDRANT_CLOUD_CONSOLE_URL, default https://cloud.qdrant.io)
+      --context string       Override the active context (env: QDRANT_CLOUD_CONTEXT)
+      --debug                Enable debug logging to stderr
+      --endpoint string      gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)
+      --json                 Output as JSON
 ```
 
 ### SEE ALSO

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/dustin/go-humanize v1.0.1
 	github.com/google/uuid v1.6.0
 	github.com/jedib0t/go-pretty/v6 v6.8.1
+	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c
 	github.com/qdrant/qdrant-cloud-public-api v0.158.0
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/spf13/cobra v1.10.2

--- a/go.sum
+++ b/go.sum
@@ -67,6 +67,8 @@ github.com/mattn/go-runewidth v0.0.16 h1:E5ScNMtiwvlvB5paMFdw9p4kSQzbXFikJ5SQO6T
 github.com/mattn/go-runewidth v0.0.16/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
 github.com/pelletier/go-toml/v2 v2.2.4 h1:mye9XuhQ6gvn5h28+VilKrrPoQVanw5PMw/TB0t5Ec4=
 github.com/pelletier/go-toml/v2 v2.2.4/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
+github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c h1:+mdjkGKdHQG3305AYmdv1U2eRNDiU2ErMBj1gwrq8eQ=
+github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c/go.mod h1:7rwL4CYBLnjLxUqIJNnCWiEdr3bn6IUYi15bNlnbCCU=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/qdrant/qdrant-cloud-public-api v0.158.0 h1:NUo++Q5+s50H8lQcYUJly42Kfed/+3fsSJ/w+6/5omc=
@@ -131,6 +133,7 @@ golang.org/x/oauth2 v0.36.0/go.mod h1:YDBUJMTkDnJS+A4BP4eZBjCqtokkg1hODuPjwiGPO7
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.47.0 h1:o7XGOvZQCADBQQ4Y7VNq2dRWQR7JmOUW8Kxx4ZsNgWs=
 golang.org/x/sys v0.47.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -57,6 +57,7 @@ Documentation: https://github.com/qdrant/qcloud-cli`,
 	cmd.PersistentFlags().String("api-key", "", "Management API Key (env: QDRANT_CLOUD_API_KEY)")
 	cmd.PersistentFlags().String("account-id", "", "Qdrant Cloud Account ID (env: QDRANT_CLOUD_ACCOUNT_ID)")
 	cmd.PersistentFlags().String("endpoint", "", "gRPC API endpoint (env: QDRANT_CLOUD_ENDPOINT, default grpc.cloud.qdrant.io:443)")
+	cmd.PersistentFlags().String("console-url", "", "Qdrant Cloud web console base URL (env: QDRANT_CLOUD_CONSOLE_URL, default https://cloud.qdrant.io)")
 	cmd.PersistentFlags().Bool("json", false, "Output as JSON")
 	cmd.PersistentFlags().String("context", "", "Override the active context (env: QDRANT_CLOUD_CONTEXT)")
 	_ = cmd.MarkFlagFilename("config")
@@ -67,6 +68,7 @@ Documentation: https://github.com/qdrant/qcloud-cli`,
 	s.Config.BindPFlag(config.KeyAPIKey, cmd.PersistentFlags().Lookup("api-key"))
 	s.Config.BindPFlag(config.KeyAccountID, cmd.PersistentFlags().Lookup("account-id"))
 	s.Config.BindPFlag(config.KeyEndpoint, cmd.PersistentFlags().Lookup("endpoint"))
+	s.Config.BindPFlag(config.KeyConsoleURL, cmd.PersistentFlags().Lookup("console-url"))
 
 	cmd.AddCommand(account.NewCommand(s))
 	cmd.AddCommand(version.NewCommand(s))

--- a/internal/cmd/cluster/cluster.go
+++ b/internal/cmd/cluster/cluster.go
@@ -28,6 +28,7 @@ func NewCommand(s *state.State) *cobra.Command {
 		newKeyCommand(s),
 		newScaleCommand(s),
 		newLogsCommand(s),
+		newDashboardCommand(s),
 	)
 	return cmd
 }

--- a/internal/cmd/cluster/dashboard.go
+++ b/internal/cmd/cluster/dashboard.go
@@ -1,0 +1,92 @@
+package cluster
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	clusterv1 "github.com/qdrant/qdrant-cloud-public-api/gen/go/qdrant/cloud/cluster/v1"
+
+	"github.com/qdrant/qcloud-cli/internal/cmd/base"
+	"github.com/qdrant/qcloud-cli/internal/cmd/completion"
+	"github.com/qdrant/qcloud-cli/internal/cmd/util"
+	"github.com/qdrant/qcloud-cli/internal/state"
+)
+
+func newDashboardCommand(s *state.State) *cobra.Command {
+	return base.Cmd{
+		Example: `# Open a cluster's dashboard in your default browser
+qcloud cluster dashboard 7b2ea926-724b-4de2-b73a-8675c42a6ebe
+
+# Print the dashboard URL instead of opening a browser (headless/SSH)
+qcloud cluster dashboard 7b2ea926-724b-4de2-b73a-8675c42a6ebe --print-url`,
+		BaseCobraCommand: func() *cobra.Command {
+			cmd := &cobra.Command{
+				Use:   "dashboard <cluster-id>",
+				Short: "Open a cluster's dashboard in your browser",
+				Long: `Open a cluster's dashboard in your default browser.
+
+The command builds the Cloud UI dashboard URL and opens it. The Cloud UI page
+handles authentication using your existing browser session and redirects to the
+cluster's dashboard.`,
+				Args: util.ExactArgs(1, "a cluster ID"),
+			}
+			cmd.Flags().Bool("print-url", false, "Print the dashboard URL instead of opening a browser")
+			return cmd
+		},
+		Run: func(s *state.State, cmd *cobra.Command, args []string) error {
+			clusterID := args[0]
+
+			ctx := cmd.Context()
+			client, err := s.Client(ctx)
+			if err != nil {
+				return err
+			}
+
+			accountID, err := s.AccountID()
+			if err != nil {
+				return err
+			}
+
+			// Confirm the cluster exists so we give a clear error instead of
+			// opening a browser to a URL that will not resolve.
+			if _, err := client.Cluster().GetCluster(ctx, &clusterv1.GetClusterRequest{
+				AccountId: accountID,
+				ClusterId: clusterID,
+			}); err != nil {
+				return fmt.Errorf("failed to find cluster %s: %w", clusterID, err)
+			}
+
+			dashURL, err := dashboardURL(s.Config.ConsoleURL(), accountID, clusterID)
+			if err != nil {
+				return err
+			}
+
+			printURL, _ := cmd.Flags().GetBool("print-url")
+			if printURL {
+				fmt.Fprintln(cmd.OutOrStdout(), dashURL)
+				return nil
+			}
+
+			fmt.Fprintf(cmd.ErrOrStderr(), "Opening dashboard for cluster %s in your browser...\n", clusterID)
+			if err := s.OpenBrowser(dashURL); err != nil {
+				fmt.Fprintf(cmd.ErrOrStderr(), "Could not open a browser. Open this URL manually:\n%s\n", dashURL)
+				return fmt.Errorf("failed to open browser: %w", err)
+			}
+			return nil
+		},
+		ValidArgsFunction: completion.ClusterIDCompletion(s),
+	}.CobraCommand(s)
+}
+
+// dashboardURL builds the Cloud UI dashboard URL for a cluster from the web
+// console base URL, account ID, and cluster ID.
+func dashboardURL(consoleBase, accountID, clusterID string) (string, error) {
+	base := strings.TrimRight(consoleBase, "/")
+	if _, err := url.Parse(base); err != nil {
+		return "", fmt.Errorf("invalid console URL %q: %w", consoleBase, err)
+	}
+	return url.JoinPath(base, "accounts", accountID, "clusters", clusterID, "dashboard")
+}

--- a/internal/cmd/cluster/dashboard.go
+++ b/internal/cmd/cluster/dashboard.go
@@ -75,6 +75,7 @@ cluster's dashboard.`,
 				fmt.Fprintf(cmd.ErrOrStderr(), "Could not open a browser. Open this URL manually:\n%s\n", dashURL)
 				return fmt.Errorf("failed to open browser: %w", err)
 			}
+
 			return nil
 		},
 		ValidArgsFunction: completion.ClusterIDCompletion(s),
@@ -88,5 +89,6 @@ func dashboardURL(consoleBase, accountID, clusterID string) (string, error) {
 	if _, err := url.Parse(base); err != nil {
 		return "", fmt.Errorf("invalid console URL %q: %w", consoleBase, err)
 	}
+
 	return url.JoinPath(base, "accounts", accountID, "clusters", clusterID, "dashboard")
 }

--- a/internal/cmd/cluster/dashboard_test.go
+++ b/internal/cmd/cluster/dashboard_test.go
@@ -1,0 +1,98 @@
+package cluster_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	clusterv1 "github.com/qdrant/qdrant-cloud-public-api/gen/go/qdrant/cloud/cluster/v1"
+
+	"github.com/qdrant/qcloud-cli/internal/testutil"
+)
+
+func TestDashboard_PrintURL(t *testing.T) {
+	env := testutil.NewTestEnv(t, testutil.WithAccountID("acct-1"))
+	env.Server.GetClusterCalls.Returns(&clusterv1.GetClusterResponse{
+		Cluster: &clusterv1.Cluster{Id: "cluster-123"},
+	}, nil)
+
+	opened := 0
+	env.State.SetBrowserOpener(func(string) error { opened++; return nil })
+
+	stdout, _, err := testutil.Exec(t, env, "cluster", "dashboard", "cluster-123", "--print-url")
+	require.NoError(t, err)
+	assert.Contains(t, stdout, "https://cloud.qdrant.io/accounts/acct-1/clusters/cluster-123/dashboard")
+	assert.Equal(t, 0, opened, "browser should not be opened with --print-url")
+
+	req, ok := env.Server.GetClusterCalls.Last()
+	require.True(t, ok)
+	assert.Equal(t, "acct-1", req.GetAccountId())
+	assert.Equal(t, "cluster-123", req.GetClusterId())
+}
+
+func TestDashboard_OpensBrowser(t *testing.T) {
+	env := testutil.NewTestEnv(t, testutil.WithAccountID("acct-1"))
+	env.Server.GetClusterCalls.Returns(&clusterv1.GetClusterResponse{
+		Cluster: &clusterv1.Cluster{Id: "cluster-123"},
+	}, nil)
+
+	var opened string
+	calls := 0
+	env.State.SetBrowserOpener(func(u string) error { opened = u; calls++; return nil })
+
+	_, stderr, err := testutil.Exec(t, env, "cluster", "dashboard", "cluster-123")
+	require.NoError(t, err)
+	assert.Equal(t, 1, calls)
+	assert.Equal(t, "https://cloud.qdrant.io/accounts/acct-1/clusters/cluster-123/dashboard", opened)
+	assert.Contains(t, stderr, "Opening dashboard for cluster cluster-123")
+}
+
+func TestDashboard_ClusterNotFound(t *testing.T) {
+	env := testutil.NewTestEnv(t)
+	env.Server.GetClusterCalls.Returns(nil, status.Error(codes.NotFound, "cluster not found"))
+
+	opened := 0
+	env.State.SetBrowserOpener(func(string) error { opened++; return nil })
+
+	_, _, err := testutil.Exec(t, env, "cluster", "dashboard", "cluster-123")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cluster-123")
+	assert.Equal(t, 0, opened, "browser should not be opened when the cluster is unknown")
+}
+
+func TestDashboard_MissingArgs(t *testing.T) {
+	env := testutil.NewTestEnv(t)
+
+	_, _, err := testutil.Exec(t, env, "cluster", "dashboard")
+	require.Error(t, err)
+}
+
+func TestDashboard_CustomConsoleURL_Env(t *testing.T) {
+	env := testutil.NewTestEnv(t, testutil.WithAccountID("acct-1"))
+	t.Setenv("QDRANT_CLOUD_CONSOLE_URL", "https://cloud.stage.qdrant.io")
+	env.Server.GetClusterCalls.Returns(&clusterv1.GetClusterResponse{
+		Cluster: &clusterv1.Cluster{Id: "cluster-123"},
+	}, nil)
+
+	stdout, _, err := testutil.Exec(t, env, "cluster", "dashboard", "cluster-123", "--print-url")
+	require.NoError(t, err)
+	assert.Contains(t, stdout, "https://cloud.stage.qdrant.io/accounts/acct-1/clusters/cluster-123/dashboard")
+}
+
+func TestDashboard_CustomConsoleURL_Flag(t *testing.T) {
+	env := testutil.NewTestEnv(t, testutil.WithAccountID("acct-1"))
+	env.Server.GetClusterCalls.Returns(&clusterv1.GetClusterResponse{
+		Cluster: &clusterv1.Cluster{Id: "cluster-123"},
+	}, nil)
+
+	// A trailing slash on the base is trimmed before joining the path.
+	stdout, _, err := testutil.Exec(t, env,
+		"cluster", "dashboard", "cluster-123", "--print-url",
+		"--console-url", "https://console.example.com/",
+	)
+	require.NoError(t, err)
+	assert.Contains(t, stdout, "https://console.example.com/accounts/acct-1/clusters/cluster-123/dashboard")
+}

--- a/internal/state/config/config.go
+++ b/internal/state/config/config.go
@@ -18,6 +18,7 @@ import (
 
 const (
 	defaultAPIEndpoint = "grpc.cloud.qdrant.io:443"
+	defaultConsoleURL  = "https://cloud.qdrant.io"
 	envPrefix          = "QDRANT_CLOUD"
 
 	// KeyAPIKey is the config key for the Management API key.
@@ -26,6 +27,8 @@ const (
 	KeyAccountID = "account_id"
 	// KeyEndpoint is the config key for the API endpoint.
 	KeyEndpoint = "endpoint"
+	// KeyConsoleURL is the config key for the web console base URL.
+	KeyConsoleURL = "console_url"
 )
 
 // ContextEntry holds the configuration for a single named context.
@@ -68,6 +71,7 @@ func New() *Config {
 	v.SetEnvKeyReplacer(strings.NewReplacer("-", "_", ".", "_"))
 	v.AutomaticEnv()
 	v.SetDefault(KeyEndpoint, defaultAPIEndpoint)
+	v.SetDefault(KeyConsoleURL, defaultConsoleURL)
 	return &Config{v: v}
 }
 
@@ -173,6 +177,11 @@ func (c *Config) SetAccountID(id string) {
 // Endpoint returns the API endpoint from config/env/flags.
 func (c *Config) Endpoint() string {
 	return c.v.GetString(KeyEndpoint)
+}
+
+// ConsoleURL returns the web console base URL from config/env/flags.
+func (c *Config) ConsoleURL() string {
+	return c.v.GetString(KeyConsoleURL)
 }
 
 // JSONOutput returns whether JSON output is enabled.

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"log/slog"
 
+	"github.com/pkg/browser"
+
 	"github.com/qdrant/qcloud-cli/internal/qcloudapi"
 	"github.com/qdrant/qcloud-cli/internal/selfupgrade"
 	"github.com/qdrant/qcloud-cli/internal/state/config"
@@ -22,13 +24,17 @@ type Updater interface {
 	UpdateSelf(ctx context.Context, currentVersion string) (*selfupgrade.ReleaseInfo, error)
 }
 
+// BrowserOpener opens a URL in the user's default browser.
+type BrowserOpener func(url string) error
+
 // State holds shared dependencies for all commands.
 type State struct {
-	Version string
-	Config  *config.Config
-	Logger  *slog.Logger
-	client  *qcloudapi.Client
-	updater Updater
+	Version     string
+	Config      *config.Config
+	Logger      *slog.Logger
+	client      *qcloudapi.Client
+	updater     Updater
+	openBrowser BrowserOpener
 }
 
 // New creates a new State with the given version string.
@@ -63,6 +69,19 @@ func (s *State) Client(ctx context.Context) (*qcloudapi.Client, error) {
 // SetClient injects a pre-built client, bypassing lazy creation.
 func (s *State) SetClient(c *qcloudapi.Client) {
 	s.client = c
+}
+
+// OpenBrowser opens the given URL in the user's default browser.
+func (s *State) OpenBrowser(url string) error {
+	if s.openBrowser != nil {
+		return s.openBrowser(url)
+	}
+	return browser.OpenURL(url)
+}
+
+// SetBrowserOpener injects a browser opener, bypassing the default. For testing.
+func (s *State) SetBrowserOpener(fn BrowserOpener) {
+	s.openBrowser = fn
 }
 
 // Updater returns the CLI updater, creating it lazily on first call.

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -76,6 +76,7 @@ func (s *State) OpenBrowser(url string) error {
 	if s.openBrowser != nil {
 		return s.openBrowser(url)
 	}
+
 	return browser.OpenURL(url)
 }
 


### PR DESCRIPTION
## Add `cluster dashboard` command

Adds `qcloud cluster dashboard <cluster-id>`, which opens a cluster's dashboard in your default browser.

```bash
# Open the dashboard in your browser
qcloud cluster dashboard 7b2ea926-724b-4de2-b73a-8675c42a6ebe

# Print the URL instead (headless / SSH sessions)
qcloud cluster dashboard 7b2ea926-724b-4de2-b73a-8675c42a6ebe --print-url
```

### Highlights
- Verifies the cluster exists before opening, so you get a clear error instead of a browser tab pointing at a dead URL.
- Authentication is handled by your existing browser session: the command opens the Cloud UI, which redirects to the cluster dashboard.
- `--print-url` flag for headless or remote environments where no browser is available.
- Cluster ID tab-completion.

### Supporting changes
- New `--console-url` global flag, `QDRANT_CLOUD_CONSOLE_URL` env var, and `console_url` config key (defaults to `https://cloud.qdrant.io`).
- `State.OpenBrowser` (backed by `pkg/browser`) with an injectable opener for testing.
- Regenerated command reference docs.

```rp-commits
feat(cluster): add cluster dashboard command to open up a browser tab with the qdrant web ui automatically authenticated
```