### PR TITLE
fix(cd): make the docs sync job open a PR

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,8 @@ jobs:
   sync-docs:
     runs-on: ubuntu-latest
     needs: release
+    permissions:
+      contents: read
     steps:
       - name: Checkout qcloud-cli
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -68,23 +70,36 @@ jobs:
           GH_TOKEN: ${{ secrets.LANDING_PAGE_PAT }}
           REF_NAME: ${{ github.ref_name }}
         run: |
-          if git diff --quiet -- qdrant-landing/content/documentation/cloud-cli/reference; then
-            echo "no changes to sync"
-            exit 0
-          fi
+          set -euo pipefail
+
+          reference="qdrant-landing/content/documentation/cloud-cli/reference"
+          branch="qcloud-cli-docs-sync-${REF_NAME}"
+          base="$(gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name')"
 
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-
-          branch="qcloud-cli-docs-sync-${REF_NAME}"
           git checkout -b "$branch"
-          git add qdrant-landing/content/documentation/cloud-cli/reference
+
+          # Staging is the only view that sees the untracked pages a new
+          # command adds; git diff on the worktree misses them entirely.
+          git add -A -- "$reference"
+          if git diff --cached --quiet -- "$reference"; then
+            echo "command reference is unchanged, nothing to sync"
+            exit 0
+          fi
+
           git commit -m "docs: sync qcloud CLI command reference for ${REF_NAME}"
-          git push -u origin "$branch" --force
+
+          # The branch belongs to this workflow; re-running a tag reuses it.
+          git push --force origin "$branch"
+
+          if [ -n "$(gh pr list --head "$branch" --state open --json number --jq '.[].number')" ]; then
+            echo "PR for $branch is already open, updated it in place"
+            exit 0
+          fi
 
           gh pr create \
             --title "docs: sync qcloud CLI command reference for ${REF_NAME}" \
             --body "Auto-generated from [qdrant/qcloud-cli@${REF_NAME}](https://github.com/qdrant/qcloud-cli/releases/tag/${REF_NAME}) by the release workflow." \
             --head "$branch" \
-            --base main \
-            || echo "PR already exists for $branch"
+            --base "$base"

--- a/cmd/landingdocs/main.go
+++ b/cmd/landingdocs/main.go
@@ -113,16 +113,23 @@ func convert(srcPath string) (page, error) {
 	return page{title: title, description: description, body: body}, nil
 }
 
-func frontmatter(title, description string, weight int) string {
+func frontmatter(title, description string, weight int, partition string) string {
 	short := description
 	if len(short) > 120 {
 		short = strings.TrimSpace(short[:117]) + "..."
 	}
 
-	return fmt.Sprintf(
-		"---\ntitle: %s\nshort_description: %q\ndescription: %q\nweight: %d\n---\n\n",
+	fm := fmt.Sprintf(
+		"---\ntitle: %s\nshort_description: %q\ndescription: %q\nweight: %d\n",
 		title, short, description, weight,
 	)
+
+	// Only section indexes carry a partition in the landing_page docs tree.
+	if partition != "" {
+		fm += fmt.Sprintf("partition: %s\n", partition)
+	}
+
+	return fm + "---\n\n"
 }
 
 func run(srcDir, destDir string) error {
@@ -162,10 +169,10 @@ func run(srcDir, destDir string) error {
 		var destName, fm string
 		if name == "qcloud.md" {
 			destName = "_index.md"
-			fm = frontmatter("Command Reference", p.description, 0)
+			fm = frontmatter("Command Reference", p.description, 0, "deploy")
 		} else {
 			destName = name
-			fm = frontmatter(p.title, p.description, i+1)
+			fm = frontmatter(p.title, p.description, i+1, "")
 		}
 
 		dest := filepath.Join(destDir, destName)

--- a/cmd/landingdocs/testdata/golden/_index.md
+++ b/cmd/landingdocs/testdata/golden/_index.md
@@ -3,6 +3,7 @@ title: Command Reference
 short_description: "Root command"
 description: "Root command"
 weight: 0
+partition: deploy
 ---
 
 # qcloud


### PR DESCRIPTION
The `sync-docs` job has never opened a PR against `landing_page`. The v0.26.0 run went green with `wrote 84 reference pages` followed by `no changes to sync`.

Three bugs, each enough on its own to drop the PR:

- `git diff --quiet -- <path>` only sees tracked, modified files. The `cloud-cli/reference` directory doesn't exist in `landing_page` yet, so all 84 pages were untracked and invisible. Even later, newly added command pages would stay invisible. Now it stages first and checks `git diff --cached`.
- `--base main` pointed at a branch `landing_page` doesn't have — its default is `master`. Now resolved at runtime from `defaultBranchRef`.
- `|| echo "PR already exists"` swallowed every `gh pr create` failure, including the bad base. Replaced by a `gh pr list --head` pre-check, so real failures fail the job.

Also adds `set -euo pipefail`, `permissions: contents: read`, and `partition: deploy` on the generated section index so the docs sidebar resolves for the reference pages.

Verified against a sparse clone of `landing_page`: the old check returns exit 0 on the generated tree, the new one returns exit 1 with 84 files staged, and `defaultBranchRef` resolves to `master`.

Follow-up, not fixable from this repo: `documentation/cloud-cli.md` is a leaf page there, so a `cloud-cli/` directory next to it gives Hugo two pages at the same URL and a section with no `_index.md`. It needs a `git mv` to `cloud-cli/_index.md` before or with the first sync PR.